### PR TITLE
Update .gitmodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "deps/libzrtp"]
-	path = deps/libzrtp
-	url = https://github.com/traviscross/libzrtp.git
 [submodule "deps/prometheus-cpp"]
 	path = deps/prometheus-cpp
 	url = https://github.com/jupp0r/prometheus-cpp.git


### PR DESCRIPTION
The file does accurately represent the folders found in deps/
Moreover, it causes jenkins users to run into bug JENKINS-43977

Here's the commit where libzrtp was added: https://github.com/drachtio/drachtio-server/commit/9ed406bbd66c707daf4fc8c69993891f7f2e4f3d

And here's the commit where it was quickly removed, but the module wasn't: https://github.com/drachtio/drachtio-server/commit/f7e29bba03e7a942dbbc83c425ab13d8591b6fd0
