### PR TITLE
Bugfix/webrtc disconnects before answer

### DIFF
--- a/src/invite-in-progress.cpp
+++ b/src/invite-in-progress.cpp
@@ -43,7 +43,7 @@ namespace drachtio {
 
   void IIP::cancelMaxProceedingTimer() {
 		if (m_timerMaxProceeding) {
-      DR_LOG(log_debug) << "IIP::doMaxProceedingTimerHandling " << *this;
+      DR_LOG(log_debug) << "IIP::cancelMaxProceedingTimer " << *this;
       su_timer_destroy( m_timerMaxProceeding ) ;
     }
 		m_timerMaxProceeding = nullptr ;
@@ -55,6 +55,7 @@ namespace drachtio {
     DR_LOG(log_debug) << "IIP::startMaxProceedingTimer " << *this;
     m_ppSelf = new std::weak_ptr<IIP>( shared_from_this() ) ;
     m_timerMaxProceeding = su_timer_create( su_root_task(theOneAndOnlyController->getRoot()), MAX_PROCEEDING_DURATION ) ;
+    su_timer_set(m_timerMaxProceeding, max_proceeding_timer_handler, (su_timer_arg_t *) m_ppSelf );
 	}
 
   std::ostream& operator<<(std::ostream& os, const IIP& iip) {

--- a/src/invite-in-progress.cpp
+++ b/src/invite-in-progress.cpp
@@ -59,7 +59,7 @@ namespace drachtio {
 
   std::ostream& operator<<(std::ostream& os, const IIP& iip) {
     sip_time_t alive = sip_now() - iip.m_tmCreated;
-    os << "tid:" << iip.getTransactionId() << std::dec << 
+    os << (iip.role() == uac_role ? "outbound" : "inbound") << " tid:" << iip.getTransactionId() << std::dec << 
       " alive:" << alive << "s" << std::hex << 
       " leg:" << iip.leg() << 
       " irq:" << iip.irq() <<

--- a/src/invite-in-progress.cpp
+++ b/src/invite-in-progress.cpp
@@ -19,7 +19,7 @@ namespace drachtio {
   IIP::IIP(nta_leg_t* leg, nta_incoming_t* irq, const std::string& transactionId, std::shared_ptr<SipDialog> dlg) : 
     m_leg(leg), m_irq(irq), m_orq(nullptr), m_strTransactionId(transactionId), m_dlg(dlg),
     m_role(uas_role),m_rel(nullptr), m_bCanceled(false), m_tmCreated(sip_now()) {
-      
+      m_ppSelf = new std::weak_ptr<IIP>( shared_from_this() ) ;
       m_timerMaxProceeding = su_timer_create( su_root_task(theOneAndOnlyController->getRoot()), MAX_PROCEEDING_DURATION ) ;
       DR_LOG(log_debug) << "adding IIP for incoming call " << *this;
     }
@@ -27,32 +27,27 @@ namespace drachtio {
   IIP::IIP(nta_leg_t* leg, nta_outgoing_t* orq, const string& transactionId, std::shared_ptr<SipDialog> dlg) : 
     m_leg(leg), m_irq(nullptr), m_orq(orq), m_strTransactionId(transactionId), m_dlg(dlg),
     m_role(uac_role),m_rel(nullptr), m_bCanceled(false), m_tmCreated(sip_now()) {
+      m_ppSelf = new std::weak_ptr<IIP>( shared_from_this() ) ;
       m_timerMaxProceeding = su_timer_create( su_root_task(theOneAndOnlyController->getRoot()), MAX_PROCEEDING_DURATION ) ;
       DR_LOG(log_debug) << "adding IIP for outgoing call " << *this;
     }
 
   IIP::~IIP() {
-    if( NULL != m_timerMaxProceeding ) {
-			cancelMaxProceedingTimer() ;
-			assert( m_ppSelf ) ;
-		}
-		if( m_ppSelf ) {
-			delete m_ppSelf ;
-		}
+    cancelMaxProceedingTimer() ;
+		if( m_ppSelf) delete m_ppSelf ;
   }
   
   void IIP::doMaxProceedingTimerHandling(void) {
     theOneAndOnlyController->getDialogController()->notifyMaxProceedingReachedIIP( shared_from_this() ) ;
     assert( m_ppSelf ) ;
 		delete m_ppSelf ; 
-    m_ppSelf = NULL ; 
-    m_timerMaxProceeding = NULL;
+    m_ppSelf = nullptr ; 
+    m_timerMaxProceeding = nullptr;
   }
 
   void IIP::cancelMaxProceedingTimer() {
-		assert( NULL != m_timerMaxProceeding ) ;
 		if (m_timerMaxProceeding) su_timer_destroy( m_timerMaxProceeding ) ;
-		m_timerMaxProceeding = NULL ;
+		m_timerMaxProceeding = nullptr ;
 	}
 
   std::ostream& operator<<(std::ostream& os, const IIP& iip) {

--- a/src/invite-in-progress.cpp
+++ b/src/invite-in-progress.cpp
@@ -19,13 +19,13 @@ namespace drachtio {
   IIP::IIP(nta_leg_t* leg, nta_incoming_t* irq, const std::string& transactionId, std::shared_ptr<SipDialog> dlg) : 
     m_leg(leg), m_irq(irq), m_orq(nullptr), m_strTransactionId(transactionId), m_dlg(dlg),
     m_role(uas_role),m_rel(nullptr), m_bCanceled(false), m_tmCreated(sip_now()), m_ppSelf(nullptr), m_timerMaxProceeding(nullptr) {
-      DR_LOG(log_debug) << "adding IIP for incoming call " << *this;
+      DR_LOG(log_debug) << "adding IIP " << *this;
     }
 
   IIP::IIP(nta_leg_t* leg, nta_outgoing_t* orq, const string& transactionId, std::shared_ptr<SipDialog> dlg) : 
     m_leg(leg), m_irq(nullptr), m_orq(orq), m_strTransactionId(transactionId), m_dlg(dlg),
     m_role(uac_role),m_rel(nullptr), m_bCanceled(false), m_tmCreated(sip_now()), m_ppSelf(nullptr), m_timerMaxProceeding(nullptr) {
-      DR_LOG(log_debug) << "adding IIP for outgoing call " << *this;
+      DR_LOG(log_debug) << "adding IIP " << *this;
     }
 
   IIP::~IIP() {
@@ -38,12 +38,10 @@ namespace drachtio {
 		delete m_ppSelf ; 
     m_ppSelf = nullptr ; 
     m_timerMaxProceeding = nullptr;
-    DR_LOG(log_debug) << "IIP::doMaxProceedingTimerHandling " << *this;
   }
 
   void IIP::cancelMaxProceedingTimer() {
 		if (m_timerMaxProceeding) {
-      DR_LOG(log_debug) << "IIP::cancelMaxProceedingTimer " << *this;
       su_timer_destroy( m_timerMaxProceeding ) ;
     }
 		m_timerMaxProceeding = nullptr ;
@@ -52,7 +50,6 @@ namespace drachtio {
   void IIP::startMaxProceedingTimer() {
     assert(!m_timerMaxProceeding) ;
     assert(!m_ppSelf) ;
-    DR_LOG(log_debug) << "IIP::startMaxProceedingTimer " << *this;
     m_ppSelf = new std::weak_ptr<IIP>( shared_from_this() ) ;
     m_timerMaxProceeding = su_timer_create( su_root_task(theOneAndOnlyController->getRoot()), MAX_PROCEEDING_DURATION ) ;
     su_timer_set(m_timerMaxProceeding, max_proceeding_timer_handler, (su_timer_arg_t *) m_ppSelf );

--- a/src/invite-in-progress.hpp
+++ b/src/invite-in-progress.hpp
@@ -51,7 +51,7 @@ namespace drachtio {
   struct TransactionIdTag{};
 
 	/* invites in progress */
-	class IIP {
+	class IIP  : public std::enable_shared_from_this<IIP> {
   public:
 		IIP(nta_leg_t* leg, nta_incoming_t* irq, const std::string& transactionId, std::shared_ptr<SipDialog> dlg);
 		IIP(nta_leg_t* leg, nta_outgoing_t* orq, const string& transactionId, std::shared_ptr<SipDialog> dlg);
@@ -77,6 +77,9 @@ namespace drachtio {
 		void setCanceled(void) { m_bCanceled = true; }
 		bool isCanceled(void) { return m_bCanceled; }
 
+    void cancelMaxProceedingTimer(void);
+    void doMaxProceedingTimerHandling(void);
+  
     friend std::ostream& operator<<(std::ostream& os, const IIP& iip);
 
   private:
@@ -90,6 +93,8 @@ namespace drachtio {
 		agent_role		m_role ;
 		bool 					m_bCanceled;
     sip_time_t    m_tmCreated;
+    su_timer_t*   m_timerMaxProceeding;
+    std::weak_ptr<IIP>* m_ppSelf ;
 	} ;
 
 

--- a/src/invite-in-progress.hpp
+++ b/src/invite-in-progress.hpp
@@ -77,6 +77,7 @@ namespace drachtio {
 		void setCanceled(void) { m_bCanceled = true; }
 		bool isCanceled(void) { return m_bCanceled; }
 
+    void startMaxProceedingTimer(void);
     void cancelMaxProceedingTimer(void);
     void doMaxProceedingTimerHandling(void);
   

--- a/src/invite-in-progress.hpp
+++ b/src/invite-in-progress.hpp
@@ -65,6 +65,8 @@ namespace drachtio {
 		const nta_reliable_t* rel(void) const { return m_rel; }
 		const string& getTransactionId(void) const { return m_strTransactionId; }
 
+    const agent_role role() const { return m_role; }
+
 		void setReliable(nta_reliable_t* rel) { m_rel = rel; }
 		void destroyReliable(void) {
 			if( m_rel ) {

--- a/src/sip-dialog-controller.cpp
+++ b/src/sip-dialog-controller.cpp
@@ -1795,6 +1795,7 @@ namespace drachtio {
     }
     void SipDialogController::notifyMaxProceedingReachedIIP( std::shared_ptr<IIP> iip ) {
         DR_LOG(log_info) << "SipDialogController::notifyMaxProceedingReachedIIP - tearing down transaction id " << iip->getTransactionId() ;
+        m_pController->getClientController()->removeAppTransaction( iip->getTransactionId() ) ;
         IIP_Clear(m_invitesInProgress, iip) ;
     }
 

--- a/src/sip-dialog-controller.cpp
+++ b/src/sip-dialog-controller.cpp
@@ -1793,6 +1793,11 @@ namespace drachtio {
         }
         SD_Clear(m_dialogs, dlg) ;
     }
+    void SipDialogController::notifyMaxProceedingReachedIIP( std::shared_ptr<IIP> iip ) {
+        DR_LOG(log_info) << "SipDialogController::notifyMaxProceedingReachedIIP - tearing down transaction id " << iip->getTransactionId() ;
+        IIP_Clear(m_invitesInProgress, iip) ;
+    }
+
     void SipDialogController::bindIrq( nta_incoming_t* irq ) {
         nta_incoming_bind( irq, uasCancelOrAck, (nta_incoming_magic_t *) m_pController ) ;
     }

--- a/src/sip-dialog-controller.hpp
+++ b/src/sip-dialog-controller.hpp
@@ -197,6 +197,8 @@ namespace drachtio {
     void notifyRefreshDialog( std::shared_ptr<SipDialog> dlg ) ;
     void notifyTerminateStaleDialog( std::shared_ptr<SipDialog> dlg, bool ackbye = false ) ;
 
+    void notifyMaxProceedingReachedIIP( std::shared_ptr<IIP> dlg ) ;
+
 		void logStorageCount(bool bDetail = false)  ;
 
 		/// IIP helpers 


### PR DESCRIPTION
This fixes a memory leak where drachtio, acting as a UAC, sends an INVITE to webrtc (or other client connecting via tcp/tls/wss) and after sending a 100 Trying the client closes the connection without first sending a final non-success response to the INVITE.  

Previously, this would leak the following objects:
- an IIP
- a SipDialog
- an app transaction
- a sofia sip transaction
- a tport connection

With this change, we give an invite-in-progress (IIP) 180 seconds to reach an answered or completed state.  If that timer is reached, the IIP and associated objects are destroyed.