### PR TITLE
parse arg before add

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,7 +54,9 @@ if [ "$1" = 'drachtio' ]; then
       ;;
 
     *)
-      MYARGS+=($1)
+      thisarg="${1//PUBLIC_IP/"$PUBLIC_IP"}"
+      thisarg="${thisarg//LOCAL_IP/"$LOCAL_IP"}"
+      MYARGS+=($thisarg)
       ;;
     esac
 


### PR DESCRIPTION
This allows a command line in a docker swarm yaml and the PUBLIC_IP is replaced - allowing for greater flexibility in how the command line is called.

command: 'drachtio --contact sip:*:9997;transport=udp,tcp --external-ip PUBLIC_IP --contact sips:*:443;transport=wss --external-ip PUBLIC_IP'

environment:
  - CLOUD=aws