### PR TITLE
Makefile: Fix git detection when building in a subdir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-MYVERSION=$(shell [ -e .git ] && git describe --always || echo 1.0.0)
+MYVERSION=$(shell git describe --always 2>/dev/null || echo 1.0.0)
 INCLUDES= -I${srcdir}/deps/sofia-sip/libsofia-sip-ua/su -I${srcdir}/deps/sofia-sip/libsofia-sip-ua/nta \
  -I${srcdir}/deps/sofia-sip/libsofia-sip-ua/sip -I${srcdir}/deps/sofia-sip/libsofia-sip-ua/msg \
  -I${srcdir}/deps/sofia-sip/libsofia-sip-ua/url -I${srcdir}/deps/sofia-sip/libsofia-sip-ua/tport \


### PR DESCRIPTION
This should work if you build in $srcdir/build, but it will fail if you build *outside* the source directory (e.g. $srcdir/../drachtio-build).