### PR TITLE
Add option to unregister for certain SIP verbs

### DIFF
--- a/src/client-controller.cpp
+++ b/src/client-controller.cpp
@@ -227,6 +227,25 @@ namespace drachtio {
         return true ;  
     }
 
+
+    bool ClientController::no_longer_wants_requests( client_ptr client, const string& verb ) {
+        RequestSpecifier spec( client ) ;
+        std::lock_guard<std::mutex> l( m_lock ) ;
+        // Remove all instances of this client for this verb
+        for (map_of_request_types::iterator it = m_request_types.begin(); it != m_request_types.end(); ) {
+            if (it->second.client() == client) {
+                it = m_request_types.erase(it);
+            }
+            else {
+                ++it;
+            }
+        }
+        DR_LOG(log_debug) << "Removed client for " << verb << " requests"  ;
+
+        //TODO: validate the verb is supported
+        return true ;  
+    }
+
     client_ptr ClientController::selectClientForRequestOutsideDialog(const char* keyword, const char* tag) {
         string method_name = keyword ;
         transform(method_name.begin(), method_name.end(), method_name.begin(), ::tolower);

--- a/src/client-controller.hpp
+++ b/src/client-controller.hpp
@@ -72,6 +72,7 @@ namespace drachtio {
     void addNamedService( client_ptr client, string& strAppName ) ;
 
     bool wants_requests( client_ptr client, const string& verb ) ;
+    bool no_longer_wants_requests( client_ptr client, const string& verb ) ;
 
     void addDialogForTransaction( const string& transactionId, const string& dialogId ) ;
     void addAppTransaction( client_ptr client, const string& transactionId );

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -136,6 +136,14 @@ namespace drachtio {
             }
             createResponseMsg( tokens[0], msgResponse ) ;
         }
+        else if( 0 == tokens[1].compare("remove_route") ) {
+            if( !m_controller.no_longer_wants_requests( shared_from_this(), tokens[2] ) ) {
+                DR_LOG(log_error) << "Remove route request includes unsupported verb: " << tokens[2]  ;   
+                createResponseMsg( tokens[0], msgResponse, false, "Remove route request includes unsupported verb" ) ;
+                return false ;        
+            }
+            createResponseMsg( tokens[0], msgResponse ) ;
+        }
         else if( 0 == tokens[1].compare("authenticate")) {
             string secret = tokens[2] ;
             if (tokens.size() > 3) {


### PR DESCRIPTION
The use case is to be able to drain a node of new invites while still processing in-dialog messaging. 

There is also the use case of unregistering for invites when X concurrent calls are under management, for rate limiting / throttling purposes.

Really helpful when running multiple inbound-connection srf processes to scale from a single drachtio server

In conjunction with [PR on drachtio-srf](https://github.com/drachtio/drachtio-srf/pull/168)