### PR TITLE
Broken wire protocol under load

### DIFF
--- a/src/client.hpp
+++ b/src/client.hpp
@@ -106,9 +106,6 @@ namespace drachtio {
         string m_strRemoteAddress;
         unsigned int m_nRemotePort;
 
-        string m_msgResponse;
-        string m_msgToSend;
-
         time_t m_tConnect ;
     };
 


### PR DESCRIPTION
When drachtio receives too many requests at a time, the messages can end up backing up to client.cpp (the wire-protocol connected to Node).

Under the current design the object Client - contains a std::string Buffer (m_msgToSend) to hold the data it has queued for async_write. Async_write will return - with the write queued immediatly. If another request comes in which wishes to send another wire protocol message - this then overwrites the m_msgToSend std::string corrupting the first message if it has not completed its send. Then the Node app throws a major exception and quits.

This fix uses an auto_ptr which wraps a std::string - for the lifetime of the async_write. The Client auto ptr (shared_from_this) and the auto_ptr for the buffer is maintained using a lambda which is cleaned up when the async_write completes and calls back - releasing the buffer at this point.