### PR TITLE
CI: Set 10 minutes timeout for CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           node-version: 20
       - name: run ci tests
+        timeout-minutes: 10
         run: |
           cd test
           npm install 


### PR DESCRIPTION
They can hang forever, and the default timeout is 6 hours.