### PR TITLE
Use correct size for wire protocol message

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -391,7 +391,7 @@ namespace drachtio {
 
             /* send response if indicated */
             if( !msgResponse.empty() ) {
-                int len = utf8_strlen(msgResponse);
+                int len = std::size(msgResponse);
                 auto forthelifeofsend = std::make_shared<std::string>(
                     std::to_string(len) + std::string("#") + msgResponse
                 );
@@ -449,7 +449,7 @@ read_again:
 
     template<typename T, typename S>
     void Client<T,S>::send( const string& str ) {
-        int len = utf8_strlen(str);
+        int len = std::size(str);
 
         if (0 == len) {
             DR_LOG(log_info) << "Client::send - we are unable to send this message back to client" << str; 

--- a/test/package.json
+++ b/test/package.json
@@ -14,7 +14,7 @@
     "blue-tape": "^1.0.0",
     "body-parser": "^1.18.3",
     "debug": "^3.1.0",
-    "drachtio-srf": "^4.4.63",
+    "drachtio-srf": "^5.0.0",
     "express": "4.16.3",
     "minimist": "^1.2.0",
     "pino": "^6.6.1",


### PR DESCRIPTION
Basically,  utf8_strlen is only useful if you want to display the character, but has no meaning when trying to access the data.