### PR TITLE
CI: Remove set -x from CppCheck

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -31,5 +31,4 @@ jobs:
           libunwind-dev
       - name: Run CppCheck
         run: |
-          set -x
           cppcheck --enable=warning,performance,portability,style --error-exitcode=1 src/


### PR DESCRIPTION
It is a single command, which is shown anyway. Currently the command is shown as "set -x", which is pointless.