### PR TITLE
SipDialogController: Protect against glare during reINVITE

### DIFF
--- a/src/sip-dialog-controller.cpp
+++ b/src/sip-dialog-controller.cpp
@@ -1677,7 +1677,11 @@ namespace drachtio {
         std::shared_ptr<RIP> rip  ;
 
         nta_leg_t* leg = nta_leg_by_call_id(m_pController->getAgent(), sip->sip_call_id->i_id);
-        assert(leg) ;
+        if (!leg) {
+            DR_LOG(log_warning) << "SipDialogController::processResponseToRefreshingReinvite: unable to find leg for call-id "
+                                << sip->sip_call_id->i_id << ", probably glare condition with BYE and re-INVITE";
+            return 0;
+        }
         std::shared_ptr<SipDialog> dlg ;
         if( !findDialogByLeg( leg, dlg ) ) {
             assert(0) ;


### PR DESCRIPTION
Scenario:
Session-Expires with refresher=uas

When client receives re-INVITE, it immediately sends BYE, and only then it responds with 481 to the INVITE.

This results in drachtio crash.

Fixes #401