### PR TITLE
SipDialog: Randomize session timer interval a bit

### DIFF
--- a/src/client-controller.cpp
+++ b/src/client-controller.cpp
@@ -92,7 +92,6 @@ namespace drachtio {
 
     void ClientController::start() {
         DR_LOG(log_debug) << "Client controller thread id: " << std::this_thread::get_id()  ;
-        srand (time(NULL));    
         std::thread t(&ClientController::threadFunc, this) ;
         m_thread.swap( t ) ;
             

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,8 @@ THE SOFTWARE.
 #define DRACHTIO_MAIN
 
 #include "controller.hpp"
+#include <stdlib.h>
+#include <time.h>
 
 using namespace drachtio ;
 
@@ -38,6 +40,7 @@ void handleSigPipe( int signal ) {
 }
 
 int main( int argc, char *argv[] ) {
+	srand(time(NULL));
 
 	try {
 		theOneAndOnlyController = new DrachtioController( argc, argv ) ;

--- a/src/sip-dialog.cpp
+++ b/src/sip-dialog.cpp
@@ -295,7 +295,10 @@ namespace drachtio {
 		DR_LOG(log_info) << "SipDialog::setSessionTimer: " << getCallId() << " Session expires has been set to " << nSecs << " seconds and refresher is " << (areWeRefresher() ? "us" : "them")  ;
 
 		/* if we are the refresher, then we want the timer to go off halfway through the interval */
-		if( areWeRefresher() ) m_nSessionTimerDuration /= 2 ;
+		if( areWeRefresher() ) {
+			m_nSessionTimerDuration /= 2 ;
+			m_nSessionTimerDuration += (rand() % 10000) - 5000 ;
+		}
 		m_timerSessionRefresh = su_timer_create( su_root_task(theOneAndOnlyController->getRoot()), m_nSessionTimerDuration ) ;
 
 		m_ppSelf = new std::weak_ptr<SipDialog>( shared_from_this() ) ;


### PR DESCRIPTION
Make it ±5 sec from half the input interval.

This should improve potential glare conditions.