### PR TITLE
CI: Do not fail on cppcheck/clang-analyzer errors

### DIFF
--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -36,4 +36,4 @@ jobs:
           ./autogen.sh
           mkdir -p build && cd $_
           scan-build ../configure
-          scan-build --status-bugs make
+          scan-build make

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -31,4 +31,4 @@ jobs:
           libunwind-dev
       - name: Run CppCheck
         run: |
-          cppcheck --enable=warning,performance,portability,style --error-exitcode=1 src/
+          cppcheck --enable=warning,performance,portability,style src/


### PR DESCRIPTION
The project currently has many warnings on both tools.

Until the project is clean, it makes no sense to fail every pull request for nothing.