### PR TITLE
Replace "localhost" in Contact header URIs without the user part

### DIFF
--- a/src/drachtio.cpp
+++ b/src/drachtio.cpp
@@ -814,11 +814,15 @@ namespace drachtio {
                 //well-known header
                 
                 //replace 'localhost' in certain headers with actual sip address:port
-                if( string::npos != hdrValue.find("@localhost") && (0 == hdr.compare("from") || 
-                    0 == hdr.compare("contact") ||
-                    0 == hdr.compare("to") ||
-                    0 == hdr.compare("p_asserted_identity") ) ) {
-
+                if( (
+                    (string::npos != hdrValue.find(":localhost") || string::npos != hdrValue.find("@localhost")) && 0 == hdr.compare("contact")
+                 ) || (
+                    string::npos != hdrValue.find("@localhost") && (
+                        0 == hdr.compare("from") ||
+                        0 == hdr.compare("to") ||
+                        0 == hdr.compare("p_asserted_identity")
+                    ) )
+                ) {
                     DR_LOG(log_debug) << "makeTags - hdr '" << hdrName << "' replacing host with " << host;
                     replaceHostInUri( hdrValue, host.c_str(), port.c_str() ) ;
                 }


### PR DESCRIPTION
We needed to set the Contact header manually, but without the user part because of reasons.
Currently `localhost` is only replaced when `@localhost` is found in the header which made this impossible.

This change expands the check (specifically for the Contact header) to match cases where the value might be `sip(s):localhost`.