### PR TITLE
Don't clearRIP on provisional responses to reinvite

### DIFF
--- a/src/sip-dialog-controller.cpp
+++ b/src/sip-dialog-controller.cpp
@@ -1658,7 +1658,10 @@ namespace drachtio {
                     assert(false) ;
                 }
             }
-            clearRIP( orq ) ;     
+            // Don't clear on provisional responses to reINVITE
+            if (sip->sip_cseq->cs_method == sip_method_invite && (sip->sip_status->st_status < 100 || sip->sip_status->st_status > 199)) {
+                clearRIP( orq ) ;
+            }
             msg_destroy(msg) ;   // releases reference
         }
         else {


### PR DESCRIPTION
This is what we use in our fork that I mentioned in issue https://github.com/drachtio/drachtio-server/issues/350.

I'm not sure if this is the way to solve the issue, but it's what we have been running for a year now without any issues so I figured I might as well open a PR.