### PR TITLE
fix #414

### DIFF
--- a/src/sip-dialog-controller.cpp
+++ b/src/sip-dialog-controller.cpp
@@ -603,7 +603,8 @@ namespace drachtio {
                 ,TAG_NEXT(tags) ) ;
 
             if( NULL == orq ) {
-                throw std::runtime_error("Error creating sip transaction for uac request") ;               
+              nta_leg_destroy( leg );
+              throw std::runtime_error("Error creating sip transaction for uac request");
             }
 
             msg_t* m = nta_outgoing_getrequest(orq) ; //adds a reference


### PR DESCRIPTION
If we create a leg for an outbound uac message, but then fail to create the orq (in this case, it fails because the uri is invalid) that leg that got created was being kept as the nta_agent_t 's default leg, causing subsequent requests to fail.  This PR fixes that by deleting the leg we just created if we are unable to create an orq