### PR TITLE
allow create private Via for inside request

### DIFF
--- a/src/sip-dialog-controller.cpp
+++ b/src/sip-dialog-controller.cpp
@@ -390,18 +390,6 @@ namespace drachtio {
 
                 if( orq ) {
                     DR_LOG(log_info) << "SipDialogController::doSendRequestInsideDialog - created orq " << std::hex << (void *) orq << " sending " << nta_outgoing_method_name(orq) << " to " << requestUri ;
-
-                    // Debug: print full SIP message from orq
-                    msg_t* dbgMsg = nta_outgoing_getrequest(orq);  // adds a reference
-                    if (dbgMsg) {
-                        sip_t* dbgSip = sip_object(dbgMsg);
-                        if (dbgSip) {
-                            string dbgEncodedMessage;
-                            EncodeStackMessage(dbgSip, dbgEncodedMessage);
-                            DR_LOG(log_debug) << "SipDialogController::doSendRequestInsideDialog - Full SIP message from orq:\n" << dbgEncodedMessage;
-                        }
-                        msg_destroy(dbgMsg);  // releases the reference
-                    }
                 }
             }
 

--- a/src/sip-dialog-controller.cpp
+++ b/src/sip-dialog-controller.cpp
@@ -366,7 +366,7 @@ namespace drachtio {
                     const string& destIp = dlg->getSourceAddress();
                     if (!destIp.empty()) {
                         std::shared_ptr<SipTransport> pTransport = SipTransport::findAppropriateTransport(destIp.c_str());
-                        if (pTransport && pTransport->hasTport()) {
+                        if (pTransport && pTransport->hasTportAndTpname()) {
                             customVia = pTransport->makeVia(m_pController->getHome(), destIp.c_str());
                             if (customVia) {
                                 DR_LOG(log_debug) << "SipDialogController::doSendRequestInsideDialog - created custom Via for destination IP " 

--- a/src/sip-dialog-controller.cpp
+++ b/src/sip-dialog-controller.cpp
@@ -632,6 +632,39 @@ namespace drachtio {
             }
             nta_leg_tag( leg, NULL ) ;
 
+            // Create custom Via based on destination for proper local-net handling
+            sip_via_t* customVia = NULL;
+            {
+                // Use outbound proxy host if specified, otherwise extract host from request URI
+                string destHost;
+                if (useOutboundProxy) {
+                    // Extract host from outbound proxy URL
+                    url_t* proxyUrl = url_make(m_pController->getHome(), sipOutboundProxy.c_str());
+                    if (proxyUrl && proxyUrl->url_host) {
+                        destHost = proxyUrl->url_host;
+                    }
+                    su_free(m_pController->getHome(), proxyUrl);
+                } else {
+                    // Extract host from request URI
+                    url_t* reqUrl = url_make(m_pController->getHome(), requestUri.c_str());
+                    if (reqUrl && reqUrl->url_host) {
+                        destHost = reqUrl->url_host;
+                    }
+                    su_free(m_pController->getHome(), reqUrl);
+                }
+                
+                if (!destHost.empty()) {
+                    std::shared_ptr<SipTransport> pViaTransport = SipTransport::findAppropriateTransport(destHost.c_str());
+                    if (pViaTransport && pViaTransport->hasTportAndTpname()) {
+                        customVia = pViaTransport->makeVia(m_pController->getHome(), destHost.c_str());
+                        if (customVia) {
+                            DR_LOG(log_debug) << "SipDialogController::doSendRequestOutsideDialog - created custom Via for destination " 
+                                << destHost << ": " << customVia->v_host << ":" << (customVia->v_port ? customVia->v_port : "5060");
+                        }
+                    }
+                }
+            }
+
             orq = nta_outgoing_tcreate( leg, 
                 response_to_request_outside_dialog, 
                 (nta_outgoing_magic_t*) m_pController, 
@@ -644,6 +677,8 @@ namespace drachtio {
                 ,TAG_IF( body.length(), SIPTAG_PAYLOAD_STR(body.c_str()))
                 ,TAG_IF( contentType.length(), SIPTAG_CONTENT_TYPE_STR(contentType.c_str()))
                 ,TAG_IF( forceTport, NTATAG_TPORT(tp))
+                ,TAG_IF(customVia, SIPTAG_VIA(customVia))
+                ,TAG_IF(customVia, NTATAG_USER_VIA(1))
                 ,TAG_NEXT(tags) ) ;
 
             if( NULL == orq ) {

--- a/src/sip-transports.cpp
+++ b/src/sip-transports.cpp
@@ -109,14 +109,8 @@ namespace drachtio {
       m_range = htonl(range.sin_addr.s_addr) ;
 
       uint32_t netbits = ::atoi( bits.c_str() ) ;    
-      m_netmask = ~(~uint32_t(0) >> netbits);    
-      
-      DR_LOG(log_info) << "SipTransport::init - configured local-net: " << m_strLocalNet 
-        << " (network: " << network << ", bits: " << bits 
-        << ", range: 0x" << std::hex << m_range 
-        << ", netmask: 0x" << m_netmask << std::dec << ")";
+      m_netmask = ~(~uint32_t(0) >> netbits);
     }
-    // Note: Don't log in else branch - logger may not be initialized during early construction
   }
 
   bool SipTransport::shouldAdvertisePublic( const char* address ) const {
@@ -437,19 +431,7 @@ namespace drachtio {
             p->setNetmask(~(~uint32_t(0) >> netbits));
             p->setNetwork(network);
             p->setLocalNet(network, bits);
-
-            DR_LOG(log_info) << "SipTransport::addTransports - auto-detected local-net: " << network << "/" << bits 
-              << " for transport " << hex << tp << dec << " (host: " << host 
-              << ", range: 0x" << hex << htonl(range.sin_addr.s_addr) << ", netmask: 0x" << (~(~uint32_t(0) >> netbits)) << dec << ")";
           }
-          else {
-            DR_LOG(log_info) << "SipTransport::addTransports - no auto-detection match for host: " << host 
-              << ", local-net will not be set";
-          }
-        }
-        else {
-          DR_LOG(log_info) << "SipTransport::addTransports - using configured local-net: " << p->getLocalNet() 
-            << " for transport " << hex << tp << dec;
         }
       }
     }

--- a/src/sip-transports.cpp
+++ b/src/sip-transports.cpp
@@ -307,7 +307,7 @@ namespace drachtio {
     
     DR_LOG(log_debug) << "SipTransport::makeVia - host " << host << ", port " << (port ? port : "5060") << ", transport " << transport ;
 
-    return sip_via_create(h, host.c_str(), port, transport.c_str());
+    return sip_via_create(h, host.c_str(), port, transport.c_str(), NULL);
   }
 
 

--- a/src/sip-transports.cpp
+++ b/src/sip-transports.cpp
@@ -280,9 +280,9 @@ namespace drachtio {
     DR_LOG(log_debug) << "SipTransport::getContactUri - created Contact header: " << contact;
   }
   sip_via_t* SipTransport::makeVia(su_home_t * h, const char* szRemoteHost) {
-    // Safety check: ensure we have a valid tport before proceeding
-    if (!this->hasTport()) {
-      DR_LOG(log_warning) << "SipTransport::makeVia - no valid tport, returning NULL";
+    // Safety check: ensure we have both valid tport AND tpName before proceeding
+    if (!this->hasTportAndTpname()) {
+      DR_LOG(log_warning) << "SipTransport::makeVia - no valid tport/tpName, returning NULL";
       return NULL;
     }
 

--- a/src/sip-transports.hpp
+++ b/src/sip-transports.hpp
@@ -75,6 +75,8 @@ namespace drachtio {
     void setNetwork(const string& network) { m_network = network;}
     void setNetmask(uint32_t netmask) { m_netmask = netmask;}
     void setRange(uint32_t range) { m_range = range;}
+    uint32_t getNetmask(void) const { return m_netmask; }
+    uint32_t getRange(void) const { return m_range; }
 
     void getDescription(string& s, bool shortVersion = true) ;
     void getHostport(string& s) ;

--- a/src/sip-transports.hpp
+++ b/src/sip-transports.hpp
@@ -56,6 +56,7 @@ namespace drachtio {
     void setLocalNet(const string& network, const string& bits) { m_strLocalNet = network + "/" + bits; }    
     bool shouldAdvertisePublic(const char* address) const ;
     bool isInNetwork(const char* address) const;
+    static bool isInPrivateNetwork(const char* address);
     bool hasTport(void) const { return NULL != m_tp; }
     bool hasTportAndTpname(void) const { return NULL != m_tp && NULL != m_tpName; }
     const tport_t* getTport(void) const { return m_tp; }


### PR DESCRIPTION
when drachtio server bootup, sofia-sip stack automatically add to cache list of available Via header and use external IP for these headers per transport

For request to private network via VPN, Via header contains public IP address.

now, drachtio server will check if remote IP of sip dialog is in private network CIDR, send request with private IP via header