### PR TITLE
set a default refresher on session-expiry

### DIFF
--- a/drachtio.conf.xml
+++ b/drachtio.conf.xml
@@ -134,6 +134,19 @@
         <mtu-size>4096</mtu-size>
         -->
 
+        <!-- session timer (RFC 4028) defaults.
+             default-refresher controls which side drachtio nominates as the
+             refresher when the UAC offers Session-Expires without a 'refresher'
+             parameter. RFC 4028 §9 leaves the choice to the UAS.
+                 "uac" (default) - the UAC must refresh; if it stops, we BYE.
+                                   Useful for B2BUA/SBC roles where you want
+                                   dead-peer detection on the calling side
+                                   (e.g. WebRTC clients).
+                 "uas"           - drachtio refreshes; matches endpoint-style
+                                   stacks (sofia, jsSIP, asterisk default).
+        <session-timers default-refresher="uac"/>
+        -->
+
         <!-- uncommenting this will cause all outbound new requests (i.e. requests outside of a dialog) to go through the specified proxy -->
         <!--
         <outbound-proxy>sip:10.10.10.1</outbound-proxy>

--- a/src/drachtio-config.cpp
+++ b/src/drachtio-config.cpp
@@ -40,8 +40,9 @@ namespace drachtio {
 
      class DrachtioConfig::Impl {
     public:
-        Impl( const char* szFilename, bool isDaemonized) : m_bIsValid(false), m_adminTcpPort(0), m_adminTlsPort(0), m_bDaemon(isDaemonized), 
+        Impl( const char* szFilename, bool isDaemonized) : m_bIsValid(false), m_adminTcpPort(0), m_adminTlsPort(0), m_bDaemon(isDaemonized),
         m_bConsoleLogger(false), m_captureHepVersion(3), m_mtu(0), m_udpBufferSize(0), m_bAggressiveNatDetection(false),
+        m_sessionTimerDefaultRefresher("uac"),
         m_prometheusPort(0), m_prometheusAddress("0.0.0.0"), m_tcpKeepalive(45), m_minTlsVersion(0) {
 
             // default timers
@@ -168,12 +169,28 @@ namespace drachtio {
 
                 try {
                     string nat = pt.get<string>("drachtio.sip.aggressive-nat-detection", "no") ;
-                    if (0 == nat.compare("yes") || 0 == nat.compare("YES") || 
+                    if (0 == nat.compare("yes") || 0 == nat.compare("YES") ||
                         0 == nat.compare("true") || 0 == nat.compare("TRUE") ||
                          0 == nat.compare("on") || 0 == nat.compare("ON")) {
                         m_bAggressiveNatDetection = true;
                     }
                 } catch( boost::property_tree::ptree_bad_path& e) {
+                }
+
+                /* default refresher for session timers when the UAC offers
+                   Session-Expires without a 'refresher' parameter (RFC 4028 §9
+                   leaves this to the UAS). Valid values: "uac" or "uas". */
+                try {
+                    string r = pt.get<string>("drachtio.sip.session-timers.<xmlattr>.default-refresher", "uac");
+                    boost::algorithm::to_lower(r);
+                    if (r != "uac" && r != "uas") {
+                        cerr << "invalid drachtio.sip.session-timers.default-refresher value '" << r
+                             << "' — must be 'uac' or 'uas'; defaulting to 'uac'" << endl;
+                        r = "uac";
+                    }
+                    m_sessionTimerDefaultRefresher = r;
+                } catch( boost::property_tree::ptree_bad_path& e) {
+                    m_sessionTimerDefaultRefresher = "uac";
                 }
 
                 m_minTlsVersion = pt.get<float>("drachtio.sip.tls.min-tls-version", 0);
@@ -449,6 +466,10 @@ namespace drachtio {
             return m_bAggressiveNatDetection;
         }
 
+        const string& getSessionTimerDefaultRefresher() const {
+            return m_sessionTimerDefaultRefresher;
+        }
+
         bool getPrometheusAddress( string& address, unsigned int& port ) {
             if (0 == m_prometheusPort) return false;
             address = m_prometheusAddress;
@@ -525,6 +546,7 @@ namespace drachtio {
         unsigned int m_mtu;
         unsigned int m_udpBufferSize;
         bool m_bAggressiveNatDetection;
+        string m_sessionTimerDefaultRefresher;
         string m_prometheusAddress;
         unsigned int m_prometheusPort;
         unsigned int m_tcpKeepalive;
@@ -623,6 +645,9 @@ namespace drachtio {
     }
     bool DrachtioConfig::isAggressiveNatEnabled() {
         return m_pimpl->isAggressiveNatEnabled();
+    }
+    const std::string& DrachtioConfig::getSessionTimerDefaultRefresher() const {
+        return m_pimpl->getSessionTimerDefaultRefresher();
     }
     bool DrachtioConfig::getPrometheusAddress( string& address, unsigned int& port ) const {
         return m_pimpl->getPrometheusAddress(address, port);

--- a/src/drachtio-config.hpp
+++ b/src/drachtio-config.hpp
@@ -83,7 +83,9 @@ namespace drachtio {
 
         bool getCaptureServer(string& address, unsigned int& port, uint32_t& agentId, unsigned int& version);
 
-        bool isAggressiveNatEnabled(void);   
+        bool isAggressiveNatEnabled(void);
+
+        const std::string& getSessionTimerDefaultRefresher(void) const;
 
         bool getPrometheusAddress( string& address, unsigned int& port ) const ;
 

--- a/src/sip-dialog-controller.cpp
+++ b/src/sip-dialog-controller.cpp
@@ -1304,13 +1304,28 @@ namespace drachtio {
                             dlg->setSessionTimer(interval, who) ;
                             su_free( m_pController->getHome(), se ) ;
                         }
-                        else if (sip->sip_session_expires && sip->sip_session_expires->x_refresher) {
+                        else if (sip->sip_session_expires) {
                             sip_session_expires_t* se = sip->sip_session_expires;
-                            sessionExpires = sip_session_expires_copy(m_pController->getHome(), se);
                             unsigned long interval = std::max((unsigned long) 90, se->x_delta);
-                            SipDialog::SessionRefresher_t who = !se->x_refresher || 0 == strcmp( se->x_refresher, "uac") ? SipDialog::they_are_refresher : SipDialog::we_are_refresher;
+                            /* RFC 4028 sec 9: the 2xx MUST include a refresher parameter
+                               even if the UAC's offer omitted it. The RFC leaves the
+                               choice of "uac" or "uas" to the UAS when no preference
+                               was expressed; we let the operator pick the default via
+                               drachtio.conf.xml (sip/session-timers/@default-refresher),
+                               and fall back to "uac" — see DrachtioConfig. */
+                            const string& configuredDefault = m_pController->getConfig()->getSessionTimerDefaultRefresher();
+                            const char* refresher = (se->x_refresher && *se->x_refresher) ? se->x_refresher : configuredDefault.c_str();
+                            SipDialog::SessionRefresher_t who = 0 == strcmp(refresher, "uac") ?
+                                SipDialog::they_are_refresher : SipDialog::we_are_refresher;
 
-                            if (who == SipDialog::we_are_refresher) {
+                            ostringstream seHdr;
+                            seHdr << interval << ";refresher=" << refresher;
+                            sessionExpires = sip_session_expires_make(m_pController->getHome(), seHdr.str().c_str());
+
+                            if (!se->x_refresher) {
+                                DR_LOG(log_debug) << "SipDialogController::doRespondToSipRequest - UAC offered Session-Expires without refresher, defaulting to refresher=" << refresher << ", interval will be " << interval  ;
+                            }
+                            else if (who == SipDialog::we_are_refresher) {
                                 DR_LOG(log_debug) << "SipDialogController::doRespondToSipRequest - UAC asked us to refresh, interval will be " << interval  ;
                             }
                             else {

--- a/test/reinvite-tests.js
+++ b/test/reinvite-tests.js
@@ -89,3 +89,43 @@ test('uas sends BYE if session expires without expected UAC refresh', (t) => {
       stop();
     });
 });
+
+test('uas defaults refresher=uac and BYEs when Session-Expires offered without a refresher', (t) => {
+  let uas, p;
+  return start(null, ['--memory-debug'])
+    .then(() => {
+      uas = new Uas();
+      return uas.connect();
+    })
+    .then(() => {
+      p = uas.handleSessionExpired();
+      return;
+    })
+    .then(() => {
+      // The sipp scenario asserts the 200 OK contains "refresher=uac" via an
+      // <ereg check_it="true"> action — sipp will exit non-zero (rejecting the
+      // execCmd promise) if drachtio omits the parameter. It then deliberately
+      // skips refreshing so drachtio must BYE when the session interval expires.
+      return execCmd('sipp -sf ./uac-session-expires-no-refresher.xml 127.0.0.1:5090 -m 1', {cwd: './scenarios'});
+    })
+    .then(() => {
+      return p;
+    })
+    .then(() => {
+      t.pass('200 OK included refresher=uac and drachtio BYEd on session expiry');
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          uas.disconnect();
+          resolve();
+        }, 1000);
+      });
+    })
+    .then(() => {
+      return stop();
+    })
+    .catch((err) => {
+      t.fail(`failed with error ${err}`);
+      if (uas) uas.disconnect();
+      stop();
+    });
+});

--- a/test/scenarios/uac-session-expires-no-refresher.xml
+++ b/test/scenarios/uac-session-expires-no-refresher.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- This program is free software; you can redistribute it and/or      -->
+<!-- modify it under the terms of the GNU General Public License as     -->
+<!-- published by the Free Software Foundation; either version 2 of the -->
+<!-- License, or (at your option) any later version.                    -->
+<!--                                                                    -->
+<!-- This program is distributed in the hope that it will be useful,    -->
+<!-- but WITHOUT ANY WARRANTY; without even the implied warranty of     -->
+<!-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the      -->
+<!-- GNU General Public License for more details.                       -->
+
+<!--                                                                    -->
+<!-- UAC offers Session-Expires WITHOUT a refresher parameter.          -->
+<!-- Per RFC 4028 sec 9 the UAS MUST include a refresher parameter in   -->
+<!-- the 2xx response. drachtio should default the refresher to "uac"   -->
+<!-- and arm a session timer that will fire a BYE if the UAC does not   -->
+<!-- send a refresh in time.                                            -->
+<!--                                                                    -->
+
+<scenario name="UAC session-expires without refresher">
+  <send retrans="500">
+    <![CDATA[
+
+      INVITE sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag00[call_number]
+      To: [service] <sip:[service]@[remote_ip]:[remote_port]>
+      Call-ID: [call_id]
+      CSeq: 1 INVITE
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Session-Expires: 90
+      Supported: timer
+      Subject: uac-session-expires-no-refresher
+      Content-Type: application/sdp
+      Content-Length: [len]
+
+      v=0
+      o=user1 53655765 2353687637 IN IP[local_ip_type] [local_ip]
+      s=-
+      c=IN IP[media_ip_type] [media_ip]
+      t=0 0
+      m=audio [media_port] RTP/AVP 0
+      a=rtpmap:0 PCMU/8000
+
+    ]]>
+  </send>
+
+  <recv response="100"
+        optional="true">
+  </recv>
+
+  <recv response="180" optional="true">
+  </recv>
+
+  <recv response="183" optional="true">
+  </recv>
+
+  <!-- The 2xx must echo Session-Expires and include refresher=uac      -->
+  <!-- (the UAC offered no refresher so the UAS picks one — we expect    -->
+  <!-- drachtio to default to refresher=uac).                            -->
+  <recv response="200" rtd="true">
+    <action>
+      <ereg regexp="refresher=uac"
+            search_in="hdr"
+            header="Session-Expires:"
+            check_it="true"
+            assign_to="1" />
+      <log message="200 OK Session-Expires refresher param matched: [$1]"/>
+    </action>
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      ACK sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag00[call_number]
+      To: [service] <sip:[service]@[remote_ip]:[remote_port]>[peer_tag_param]
+      Call-ID: [call_id]
+      CSeq: 1 ACK
+      Contact: sip:sipp@[local_ip]:[local_port]
+      Max-Forwards: 70
+      Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- We deliberately do NOT send a refresh. drachtio should fire a    -->
+  <!-- BYE when the session interval expires.                            -->
+  <recv request="BYE">
+  </recv>
+
+  <send>
+    <![CDATA[
+
+      SIP/2.0 200 OK
+      [last_Via:]
+      [last_From:]
+      [last_To:]
+      [last_Call-ID:]
+      [last_CSeq:]
+      Contact: <sip:[local_ip]:[local_port];transport=[transport]>
+      Content-Length: 0
+
+    ]]>
+    <action>
+      <ereg regexp="Session timer expired" search_in="hdr" header="Reason:" check_it="true" assign_to="2" />
+      <log message="BYE Reason matched: [$2]"/>
+    </action>
+  </send>
+
+  <ResponseTimeRepartition value="10, 20, 30, 40, 50, 100, 150, 200"/>
+  <CallLengthRepartition value="10, 50, 100, 500, 1000, 5000, 10000"/>
+
+</scenario>


### PR DESCRIPTION
When a UAC offered Session-Expires without a refresher= parameter, drachtio failed to negotiate session timers entirely:

The 200 OK was sent with no Session-Expires header (RFC 4028 §9 violation).
No session timer was armed on the dialog.
The dialog only acquired a timer at the next UAC-driven UPDATE/re-INVITE refresh (~45s later), which itself carried refresher=uac. As a result, calls that ended before that first refresh — common for short WebRTC calls — left orphaned dialogs forever, since neither side had an obligation or trigger to BYE.

This change makes the UAS path always negotiate a session timer when the UAC offers one, defaulting the refresher to a configurable value (default uac).

**Root cause**
SipDialogController::doRespondToSipRequest had three response branches for INVITE 2xx:

App explicitly set Session-Expires in response headers → use it. ✅
Request had Session-Expires AND x_refresher set → echo back. ✅
Request had Session-Expires but no x_refresher → fell through, no timer, no header. ❌
Branch (3) was the bug. Removing the x_refresher predicate from the guard, defaulting the refresher when the UAC didn't pick one, and explicitly building the response header with that refresher fixes both halves.

**Relevant RFC text**
**RFC 4028 §7.1 — UAC Behavior** (the precondition: a UAC is allowed to omit the refresher):

If the UAC wishes to indicate that it will perform the refreshes, it inserts the 'refresher' parameter with the value 'uac'. If it wishes to indicate that the UAS should perform the refreshes, it inserts the 'refresher' parameter with the value 'uas'. If the UAC has no preference, it does not include the 'refresher' parameter in the request.

**RFC 4028 §9** — Generating an Initial Session Refresh Request / Processing the 2xx:

The UAS MUST set the value of the refresher parameter in the Session-Expires header field in the 2xx response.

If the UAS wishes to accept the request, it copies the value of the Session-Expires header field from the request into the 2xx response.

**RFC 4028 §9, Table 2** — what the UAS picks when the offer omitted the refresher (both UAC and UAS support the extension):

UAC supports     'refresher' in    'refresher' in
extension?       request           response
─────────────    ──────────────    ────────────────
Y                none              uas or uac
i.e. the spec mandates that the UAS produce a refresher= value but explicitly leaves the choice of uas vs uac to the UAS implementation.

**Fix**
src/sip-dialog-controller.cpp — doRespondToSipRequest, INVITE 2xx path:

Branch 2's guard relaxed from sip->sip_session_expires && sip->sip_session_expires->x_refresher to just sip->sip_session_expires.
When the UAC's offer omitted the refresher, default to a configurable value (see config below) — uac out of the box.
Build the response Session-Expires explicitly via sip_session_expires_make("<interval>;refresher=<r>") so the parameter is always present on the wire (the previous sip_session_expires_copy would propagate the missing refresher and produce a non-compliant 200 OK even when this branch did fire).
Arm the dialog session timer (SipDialog::setSessionTimer) on every accepted offer, regardless of which side ends up as the refresher.
New configuration option
drachtio.conf.xml:

```
<sip>
  <session-timers default-refresher="uac"/>
</sip>
```
Valid values: "uac" or "uas". Invalid input falls back to "uac" with a stderr warning. Only consulted when the UAC's offer didn't specify a refresher; an explicit refresher in the request is still honoured.

Default uac was chosen because:

It matches drachtio's pre-existing convention elsewhere in the same file (sip-dialog-controller.cpp:893–898, :1654–1656, :1786–1797, :1861–1867 — all treat absent-refresher as "UAC is the refresher").
It gives B2BUA / SBC deployments dead-peer detection on the calling side: if a WebRTC client closes its tab and stops refreshing, drachtio BYEs the dialog at expiry instead of leaking it. This was the original symptom that motivated this PR.
RFC 4028 explicitly permits either choice (Table 2 above).
Operators who prefer endpoint-style behaviour (sofia-sip / JsSIP / Asterisk default) can set default-refresher="uas".

**Plumbing**
src/drachtio-config.hpp: new getSessionTimerDefaultRefresher() accessor.
src/drachtio-config.cpp: parses drachtio.sip.session-timers/@default-refresher, validates, defaults to "uac". Member initialized in the Impl constructor so it's always defined even if the config key is absent.
src/sip-dialog-controller.cpp: reads the value via m_pController->getConfig()->getSessionTimerDefaultRefresher().

**Tests**
test/scenarios/uac-session-expires-no-refresher.xml — new sipp scenario:

Sends INVITE with Session-Expires: 90 and Supported: timer, no refresher= parameter.
Asserts the 200 OK contains refresher=uac via <ereg check_it="true" header="Session-Expires:">. Sipp will fail the call (and the test) if the parameter is missing — directly catches the Session-Expires half of the bug.
Deliberately does not send a refresh.
Asserts a BYE arrives with Reason: ...Session timer expired — directly catches the timer-arming half of the bug.
test/reinvite-tests.js — new test uas defaults refresher=uac and BYEs when Session-Expires offered without a refresher, modelled on the existing session-expiry test, reusing Uas#handleSessionExpired() for the drachtio-side destroy-reason assertion.

The pre-existing uac-session-expires.xml scenario (which sends explicit refresher=uac) is unchanged and still passes — the fix is additive.

**Backwards compatibility**
Default behaviour is what every existing deployment already wanted (the bug being fixed).
Existing apps that explicitly set Session-Expires in response headers still take precedence (Branch 1 unchanged).
Existing UACs that send refresher= explicitly still get echoed verbatim.
Operators can revert to RFC §9 Table 2's other valid choice via config.