### PR TITLE
ci: bump CI timeout from 10 to 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Match the jambonz fork ([jambonz/drachtio-server#20](https://github.com/jambonz/drachtio-server/pull/20)) for parity. Suite runs in ~3.5 min locally and ~5-7 min on Linux CI; 15 min is a comfortable ceiling without being a 20-min runner-slot burn on regression.