### PR TITLE
Fix build on Ubuntu 24.04 (CMake 4.x, Boost 1.83)

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -504,40 +504,33 @@ read_again:
 
     template<>
     void Client<socket_t>::async_connect() {
-        boost::asio::ip::tcp::resolver::query query(m_host, m_port) ;
         boost::asio::ip::tcp::resolver resolver(m_controller.getIOService());
-        tcp::resolver::iterator endpointIterator = resolver.resolve(query);
-        tcp::endpoint endpoint = *endpointIterator;
+        auto endpoints = resolver.resolve(m_host, m_port);
 
-        m_sock.async_connect(endpoint, std::bind(&BaseClient::connect_handler, shared_from_this(), std::placeholders::_1, ++endpointIterator));
+        boost::asio::async_connect(m_sock, endpoints,
+            std::bind(&BaseClient::connect_handler, shared_from_this(),
+                std::placeholders::_1, std::placeholders::_2));
     }
 
     template<>
-    void Client<socket_t>::connect_handler(const boost::system::error_code& ec, tcp::resolver::iterator endpointIterator) {
+    void Client<socket_t>::connect_handler(const boost::system::error_code& ec, const tcp::endpoint& endpoint) {
         if( !ec ) {
             DR_LOG(log_debug) << "Client::connect_handler tcp - successfully connected to " <<
-            endpoint_address() << ":" << endpoint_port() ;
+            endpoint.address().to_string() << ":" << endpoint.port() ;
 
         m_controller.join( shared_from_this() ) ;
 
         setTcpKeepAlive(m_sock.native_handle());
 
         m_sock.async_read_some(boost::asio::buffer(m_readBuf),
-            std::bind( &BaseClient::read_handler, shared_from_this(), std::placeholders::_1, 
+            std::bind( &BaseClient::read_handler, shared_from_this(), std::placeholders::_1,
             std::placeholders::_2 ) ) ;
 
         //TODO: set a timeout of 2 secs or so for remote side to authenticate
 
         }
-        else if( endpointIterator != tcp::resolver::iterator() ) {
-            DR_LOG(log_debug) << "Client::connect_handler tcp - failed to connecte to " <<
-            endpoint_address() << ":" << endpoint_port() ;
-            m_sock.close() ;
-            tcp::endpoint endpoint = *endpointIterator;
-            m_sock.async_connect(endpoint, std::bind(&BaseClient::connect_handler, shared_from_this(), std::placeholders::_1, ++endpointIterator));
-        }
         else {
-            // final failure
+            // all endpoints exhausted
             DR_LOG(log_warning) << "Client::connect_handler tcp - unable to connect to " << m_host << ":" << m_port ;
             m_controller.outboundFailed(m_transactionId);
         }
@@ -575,32 +568,25 @@ read_again:
 
     template<>
     void Client<ssl_socket_t, ssl_socket_t::lowest_layer_type>::async_connect() {
-        boost::asio::ip::tcp::resolver::query query(m_host, m_port) ;
         boost::asio::ip::tcp::resolver resolver(m_controller.getIOService());
-        tcp::resolver::iterator endpointIterator = resolver.resolve(query);
-        tcp::endpoint endpoint = *endpointIterator;
+        auto endpoints = resolver.resolve(m_host, m_port);
 
-        m_sock.lowest_layer().async_connect(endpoint, std::bind(&BaseClient::connect_handler, shared_from_this(), std::placeholders::_1, ++endpointIterator));
+        boost::asio::async_connect(m_sock.lowest_layer(), endpoints,
+            std::bind(&BaseClient::connect_handler, shared_from_this(),
+                std::placeholders::_1, std::placeholders::_2));
     }
 
     template<>
-    void Client<ssl_socket_t, ssl_socket_t::lowest_layer_type>::connect_handler(const boost::system::error_code& ec, tcp::resolver::iterator endpointIterator) {
+    void Client<ssl_socket_t, ssl_socket_t::lowest_layer_type>::connect_handler(const boost::system::error_code& ec, const tcp::endpoint& endpoint) {
         if( !ec ) {
-            DR_LOG(log_debug) << "Client::connect_handler tls - successfully connected to " << m_sock.lowest_layer().remote_endpoint().address().to_string() << 
-                ":" << m_sock.lowest_layer().remote_endpoint().port() ;
+            DR_LOG(log_debug) << "Client::connect_handler tls - successfully connected to " <<
+                endpoint.address().to_string() << ":" << endpoint.port() ;
 
             m_controller.join( shared_from_this() ) ;
             m_sock.async_handshake(boost::asio::ssl::stream_base::client, std::bind(&BaseClient::handle_handshake, shared_from_this(), std::placeholders::_1));
         }
-        else if( endpointIterator != tcp::resolver::iterator() ) {
-            DR_LOG(log_debug) << "Client::connect_handler tls - failed to connect to "  << m_sock.lowest_layer().remote_endpoint().address().to_string() << 
-                ":" << m_sock.lowest_layer().remote_endpoint().port() ;
-            m_sock.lowest_layer().close() ;
-            tcp::endpoint endpoint = *endpointIterator;
-            m_sock.lowest_layer().async_connect(endpoint, std::bind(&BaseClient::connect_handler, shared_from_this(), std::placeholders::_1, ++endpointIterator));
-        }
         else {
-            // final failure
+            // all endpoints exhausted
             DR_LOG(log_warning) << "Client::connect_handler tls - unable to connect to " << m_host << ":" << m_port ;
             m_controller.outboundFailed(m_transactionId);
         }

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -55,7 +55,7 @@ namespace drachtio {
         virtual void start() = 0;
 
         virtual void async_connect() = 0;
-        virtual void connect_handler(const boost::system::error_code& ec, boost::asio::ip::tcp::resolver::iterator endpointIterator) = 0;
+        virtual void connect_handler(const boost::system::error_code& ec, const boost::asio::ip::tcp::endpoint& endpoint) = 0;
         virtual void read_handler( const boost::system::error_code& ec, std::size_t bytes_transferred ) = 0;
         virtual void write_handler( const boost::system::error_code& ec, std::size_t bytes_transferred ) = 0;
 
@@ -124,7 +124,7 @@ namespace drachtio {
         ~Client() {}
 
         void async_connect();
-        void connect_handler(const boost::system::error_code& ec, boost::asio::ip::tcp::resolver::iterator endpointIterator);
+        void connect_handler(const boost::system::error_code& ec, const boost::asio::ip::tcp::endpoint& endpoint);
         void read_handler( const boost::system::error_code& ec, std::size_t bytes_transferred );
         void write_handler( const boost::system::error_code& ec, std::size_t bytes_transferred );
 

--- a/src/test_https.cpp
+++ b/src/test_https.cpp
@@ -22,7 +22,7 @@ class client
 public:
   client(boost::asio::io_service& io_service,
       boost::asio::ssl::context& context,
-      boost::asio::ip::tcp::resolver::iterator endpoint_iterator,
+      const boost::asio::ip::tcp::resolver::results_type& endpoints,
       const char* servername)
     : socket_(io_service, context)
   {
@@ -32,7 +32,7 @@ public:
     socket_.set_verify_callback(
         std::bind(&client::verify_certificate, this, std::placeholders::_1, std::placeholders::_2));
 
-    boost::asio::async_connect(socket_.lowest_layer(), endpoint_iterator, std::bind(&client::handle_connect, this, std::placeholders::_1));
+    boost::asio::async_connect(socket_.lowest_layer(), endpoints, std::bind(&client::handle_connect, this, std::placeholders::_1));
   }
 
   bool verify_certificate(bool preverified,
@@ -131,15 +131,14 @@ int main(int argc, char* argv[])
     boost::asio::io_service io_service;
 
     boost::asio::ip::tcp::resolver resolver(io_service);
-    boost::asio::ip::tcp::resolver::query query(argv[1], argv[2]);
-    boost::asio::ip::tcp::resolver::iterator iterator = resolver.resolve(query);
+    auto endpoints = resolver.resolve(argv[1], argv[2]);
 
     boost::asio::ssl::context ctx(boost::asio::ssl::context::sslv23);
 
     //ctx.load_verify_file("ca.pem");
     ctx.set_default_verify_paths() ;
 
-    client c(io_service, ctx, iterator, argv[1]);
+    client c(io_service, ctx, endpoints, argv[1]);
 
     io_service.run();
   }


### PR DESCRIPTION
## Summary

`drachtio-server` no longer builds on a stock Ubuntu 24.04 host because two of its dependencies regressed against the system toolchain:

1. **CMake 4.x rejects the bundled `deps/hiredis` v1.2.0.** CMake 4.0 removed compatibility with `cmake_minimum_required` versions below 3.5 ([CMake 4.0 release notes](https://cmake.org/cmake/help/latest/release/4.0.html)), and hiredis v1.2.0 declares `cmake_minimum_required(VERSION 3.0.0)`. The submodule sub-build aborts before producing `libhiredis.a`:

   ```
   CMake Error at CMakeLists.txt:1 (CMAKE_MINIMUM_REQUIRED):
     Compatibility with CMake < 3.5 has been removed from CMake.
   make[1]: *** [Makefile:1323: ../deps/hiredis/libhiredis.a] Error 1
   ```

2. **Boost 1.83 has removed the legacy Asio resolver types** used by `src/client.{hpp,cpp}` and `src/test_https.cpp`. `boost::asio::ip::tcp::resolver::iterator` and `resolver::query` are gone in modern Boost.Asio:

   ```
   ../src/client.hpp:58:75: error:
     'boost::asio::ip::tcp::resolver::iterator' has not been declared
   ```

## Changes

Two independent commits in this PR:

- **`client: migrate to Boost.Asio 1.66+ resolver API`** — moves the admin-connection client (`src/client.{hpp,cpp}`) and the standalone `src/test_https.cpp` over to the resolver API introduced in [Boost 1.66](https://www.boost.org/users/history/version_1_66_0.html): `resolver.resolve(host, port)` returning `results_type`, the range overload of `boost::asio::async_connect` (which iterates over all returned endpoints internally), and a `(error_code, endpoint)` handler signature. Behavior is equivalent. As a small side benefit, the success log on the TCP path now reports the actual connected endpoint rather than the unset `m_strRemoteAddress`/`m_nRemotePort` for outbound clients.

- **`update hiredis submodule to v1.3.0`** — bumps `deps/hiredis` from `v1.2.0` (Jul 2023) to [`v1.3.0`](https://github.com/redis/hiredis/releases/tag/v1.3.0) (Apr 2025), which raised hiredis's CMake minimum to `3.7.0`. The drachtio side is API-compatible: `src/blacklist.cpp` uses only `redisConnect`, `redisCommand`, `redisReply`, `freeReplyObject`, and `REDIS_REPLY_ARRAY`, all unchanged across this range. The CMake options drachtio passes in `Makefile.am` (`-DBUILD_SHARED_LIBS=OFF -DENABLE_SSL=ON`) and the linked artifact (`libhiredis.a`) are unchanged.

## Verification

Tested in a fresh Ubuntu 24.04 container (`ubuntu:24.04` base image, CMake 4.x, Boost 1.83, g++ 13.3, OpenSSL 3.0.13):

- `./bootstrap.sh && ../configure CPPFLAGS='-DNDEBUG' && make` completes with exit 0.
- Both original errors are absent from the build log.
- `make install` produces `/usr/local/bin/drachtio`.
- `drachtio --version` reports `v0.9.7-rc1-3-g99e9e5d00d`.
- `drachtio -f /etc/drachtio.conf.xml` starts cleanly, the admin port (9022) and SIP transports (UDP+TCP on 5060) come up, all 6 transports register.

The pre-existing Debian Bookworm build path used by `Dockerfile` and CI (`ubuntu-latest` → currently 22.04) is unaffected.
