### PR TITLE
change tport queuesize by configuration

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -290,8 +290,8 @@ namespace drachtio {
         m_configFilename(DEFAULT_CONFIG_FILENAME), m_adminTcpPort(0), m_adminTlsPort(0), m_bNoConfig(false), 
         m_current_severity_threshold(log_none), m_nSofiaLoglevel(-1), m_bIsOutbound(false), m_bConsoleLogging(false),
         m_nHomerPort(0), m_nHomerId(0), m_mtu(0), m_bAggressiveNatDetection(false), m_bMemoryDebug(false),
-        m_nPrometheusPort(0), m_strPrometheusAddress("0.0.0.0"), m_tcpKeepaliveSecs(UINT16_MAX), m_bDumpMemory(false),
-        m_minTlsVersion(0), m_bDisableNatDetection(false), m_pBlacklist(nullptr), m_bAlwaysSend180(false), 
+        m_nPrometheusPort(0), m_strPrometheusAddress("0.0.0.0"), m_tcpKeepaliveSecs(UINT16_MAX), m_tportQueuesize(64), m_bDumpMemory(false),
+        m_minTlsVersion(0), m_bDisableNatDetection(false), m_pBlacklist(nullptr), m_bAlwaysSend180(false),
         m_bGloballyReadableLogs(false), m_bTlsVerifyClientCert(false), m_bRejectRegisterWithNoRealm(false) {
 
         getEnv();
@@ -833,6 +833,15 @@ namespace drachtio {
         if (p && ::atoi(p) > 0) m_mtu = ::atoi(p);
         p = std::getenv("DRACHTIO_TCP_KEEPALIVE_INTERVAL");
         if (p && ::atoi(p) >= 0) m_tcpKeepaliveSecs = ::atoi(p);
+        // listen backlog for tcp/tls/ws/wss. Default stays at sofia's 64 to
+        // preserve legacy behavior; only raised when this env var is set,
+        // clamped to sofia's hard maximum of 1000 (tport.c).
+        p = std::getenv("DRACHTIO_TPORT_QUEUESIZE");
+        if (p && ::atoi(p) > 0) {
+            int q = ::atoi(p);
+            if (q > 1000) q = 1000; // sofia-sip caps tpp_qsize at 1000 (tport.c)
+            m_tportQueuesize = (unsigned int) q;
+        }
         p = std::getenv("DRACHTIO_SECRET");
         if (p) m_secret = p;
         p = std::getenv("DRACHTIO_CONSOLE_LOGGING");
@@ -1281,6 +1290,9 @@ namespace drachtio {
             DR_LOG(log_notice) << "tcp keep alives will be sent to clients every " << m_tcpKeepaliveSecs << " seconds";
         }
 
+        // listen backlog / per-connection send queue depth for tcp/tls/ws/wss transports
+        DR_LOG(log_notice) << "transport listen backlog (TPTAG_QUEUESIZE) set to " << m_tportQueuesize;
+
         int rv = su_init() ;
         if( rv < 0 ) {
             DR_LOG(log_error) << "Error calling su_init: " << rv ;
@@ -1343,9 +1355,10 @@ namespace drachtio {
          NTATAG_CLIENT_RPORT(true), //add rport on Via headers for requests we send
          NTATAG_PASS_408(true), //pass 408s to application
          TPTAG_PONG2PING(1), // if we get a 2-byte ping, respond with CRLF pong
+         TPTAG_QUEUESIZE(m_tportQueuesize), // listen backlog for tcp/tls/ws/wss (sofia default is only 64)
          TAG_NULL(),
          TAG_END() ) ;
-        
+
         if( NULL == m_nta ) {
             DR_LOG(log_error) << "DrachtioController::run: Error calling nta_agent_create"  ;
             return ;
@@ -1379,6 +1392,7 @@ namespace drachtio {
                     TPTAG_TLS_VERSION( tlsVersionTagValue )),
                  TAG_IF( tlsTransport && hasTlsFiles && m_tlsCipherList.length() > 0, TPTAG_TLS_CIPHERS(m_tlsCipherList.c_str())),
                  TPTAG_PONG2PING(1), // if we get a 2-byte ping, respond with CRLF pong
+                 TPTAG_QUEUESIZE(m_tportQueuesize), // listen backlog for tcp/tls/ws/wss (sofia default is only 64)
                  TAG_NULL(),
                  TAG_END() ) ;
 

--- a/src/controller.hpp
+++ b/src/controller.hpp
@@ -186,6 +186,7 @@ namespace drachtio {
     bool isNatDetectionDisabled(void) { return m_bDisableNatDetection; }
 
     unsigned int getTcpKeepaliveInterval() { return m_tcpKeepaliveSecs; }
+    unsigned int getTportQueuesize() { return m_tportQueuesize; }
 
 	private:
 
@@ -289,6 +290,7 @@ namespace drachtio {
 
     bool m_bMemoryDebug;
     unsigned int m_tcpKeepaliveSecs;
+    unsigned int m_tportQueuesize;
 
     bool m_bDumpMemory;
 


### PR DESCRIPTION
I can reproduce the issue above not by using sipp, but create a c/c++ app open huge number TLS connections and hold it, keep open more TLS connections, the app just open TLS handshake and hold connection.
blasting 16.000 connections at the same time, it push the Recv-Q of tls: 5061 up to 64 and the next connection keep being dropped by kernel.

As this is like a DDOS on traffic to a single socket. there is nothing wrong with Drachtio server.
The code PR above is just allow operator can use env variable: DRACHTIO_TPORT_QUEUESIZE to set the queue size