### PR TITLE
preserve transport parameter in NAT-corrected route URI

### DIFF
--- a/src/sip-dialog-controller.cpp
+++ b/src/sip-dialog-controller.cpp
@@ -870,6 +870,12 @@ namespace drachtio {
                     else {
                       url_t const * url = nta_outgoing_route_uri(orq);
                       string routeUri = string((url ? url->url_scheme : "sip")) + ":" + meta.getAddress() + ":" + meta.getPort();
+                      if (sip->sip_contact && sip->sip_contact->m_url->url_params) {
+                        char transport[32];
+                        if (url_param(sip->sip_contact->m_url->url_params, "transport", transport, sizeof(transport)) > 0) {
+                          routeUri += string(";transport=") + transport;
+                        }
+                      }
                       dlg->setRouteUri(routeUri);
                       DR_LOG(log_info) << "SipDialogController::processResponseOutsideDialog - (UAC) detected nat setting route to: " <<   routeUri;
                     }


### PR DESCRIPTION
## Summary

- When a UAC INVITE receives a 200 OK whose Contact host differs from the source IP (e.g. hostname `sip-1.example.com` vs resolved IP `185.109.99.15`), NAT detection fires and constructs a route URI from the raw source address using only scheme:host:port, dropping the `transport` parameter from the Contact
- This causes in-dialog requests (ACK, re-INVITE, BYE) to be sent over UDP even when the Contact specified `transport=tls`, because Sofia defaults to UDP for a plain `sip:` URI without a transport parameter
- The remote side never receives the ACK on its TLS connection and retransmits the 200 OK until timeout
- Fix copies the `transport` parameter from the Contact URI into the NAT-corrected route URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)