### PR TITLE
add SIGUSR1 handler to reset file sink collector state

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -965,6 +965,48 @@ namespace drachtio {
         return new src::severity_logger_mt< severity_levels >(keywords::severity = log_info);
    }
 
+    void DrachtioController::handleSigUsr1( int signal ) {
+        if( !m_sinkTextFile ) return;
+
+        DR_LOG(log_notice) << "SIGUSR1 handled - resetting file sink to rebuild collector state from disk";
+
+        // Remove the existing file sink (destroys the collector and its inflated in-memory state)
+        logging::core::get()->remove_sink( m_sinkTextFile );
+        m_sinkTextFile.reset();
+
+        // Recreate with a fresh collector that has accurate bookkeeping
+        string name, archiveDirectory;
+        unsigned int rotationSize, maxSize, minSize, maxFiles;
+        bool autoFlush;
+        if( m_Config->getFileLogTarget( name, archiveDirectory, rotationSize, autoFlush, maxSize, minSize, maxFiles ) ) {
+            m_sinkTextFile.reset(
+                new sinks::synchronous_sink< sinks::text_file_backend >(
+                    keywords::file_name = name,
+                    keywords::rotation_size = rotationSize * 1000000,
+                    keywords::auto_flush = autoFlush,
+                    keywords::time_based_rotation = sinks::file::rotation_at_time_point(0, 0, 0),
+                    keywords::open_mode = (std::ios::out | std::ios::app)
+                )
+            );
+
+            m_sinkTextFile->set_formatter( &my_formatter );
+
+            m_sinkTextFile->locked_backend()->set_file_collector(sinks::file::make_collector(
+                keywords::target = archiveDirectory,
+                keywords::max_size = maxSize * 1000000,
+                keywords::min_free_space = minSize * 1000000,
+                keywords::max_files = maxFiles
+            ));
+
+            // Scan archive directory to build accurate file list and set counter
+            m_sinkTextFile->locked_backend()->scan_for_files(sinks::file::scan_matching, true);
+
+            logging::core::get()->add_sink(m_sinkTextFile);
+
+            DR_LOG(log_notice) << "File sink reset complete - collector state rebuilt from disk";
+        }
+    }
+
     void DrachtioController::deinitializeLogging() {
         if( m_sinkSysLog ) {
            logging::core::get()->remove_sink( m_sinkSysLog ) ;

--- a/src/controller.hpp
+++ b/src/controller.hpp
@@ -115,6 +115,7 @@ namespace drachtio {
     void handleSigHup( int signal ) ;
     void handleSigTerm( int signal ) ;
     void handleSigPipe( int signal ) ;
+    void handleSigUsr1( int signal ) ;
   	void run() ;
   	src::severity_logger_mt<severity_levels>& getLogger() const { return *m_logger; }
     src::severity_logger_mt< severity_levels >* createLogger() ;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,10 @@ void handleSigTerm( int signal ) {
   theOneAndOnlyController->handleSigTerm( signal ) ;  
 }
 void handleSigPipe( int signal ) {
-  theOneAndOnlyController->handleSigPipe( signal ) ;  
+  theOneAndOnlyController->handleSigPipe( signal ) ;
+}
+void handleSigUsr1( int signal ) {
+  theOneAndOnlyController->handleSigUsr1( signal ) ;
 }
 
 int main( int argc, char *argv[] ) {
@@ -47,6 +50,7 @@ int main( int argc, char *argv[] ) {
 		signal( SIGHUP, handleSigHup ) ;
     signal( SIGTERM, handleSigTerm ) ;
     signal( SIGPIPE, handleSigPipe ) ;
+    signal( SIGUSR1, handleSigUsr1 ) ;
 		theOneAndOnlyController->run() ;
 	} catch( std::runtime_error& err ) {
 		cerr << "Uncaught exception: " << err.what() << endl ;


### PR DESCRIPTION
## Summary
- Adds a SIGUSR1 signal handler that tears down and recreates the Boost.Log text file sink with a fresh collector
- Calls `scan_for_files()` to rebuild accurate archive state from disk after the reset
- Allows log backup scripts to signal drachtio after removing archived files, without requiring a full restart

## Problem
When external processes (e.g. log backup cron jobs) delete archived log files from the archive directory, the Boost.Log file collector's in-memory bookkeeping becomes stale. Ghost entries for deleted files inflate `m_TotalSize`, which triggers premature eviction of valid archives. The collision probe in `store_file()` then reuses freed filename slots, overwriting existing log archives with new data.

## Test plan
- [x] Built and deployed to test server (10.10.148.2)
- [x] Verified SIGUSR1 logs "resetting file sink" and "reset complete" messages
- [x] Verified process stays alive after signal (same PID)
- [x] Tested delete-then-signal workflow: deleted 5 archive files, sent SIGUSR1, confirmed collector rebuilt from remaining 37 files on disk
- [x] Verified SIP stack and client connections unaffected by the reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)