### PR TITLE
feat(tport): app-level dead-connection detection for wedged TLS/TCP transports

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -290,7 +290,8 @@ namespace drachtio {
         m_configFilename(DEFAULT_CONFIG_FILENAME), m_adminTcpPort(0), m_adminTlsPort(0), m_bNoConfig(false), 
         m_current_severity_threshold(log_none), m_nSofiaLoglevel(-1), m_bIsOutbound(false), m_bConsoleLogging(false),
         m_nHomerPort(0), m_nHomerId(0), m_mtu(0), m_bAggressiveNatDetection(false), m_bMemoryDebug(false),
-        m_nPrometheusPort(0), m_strPrometheusAddress("0.0.0.0"), m_tcpKeepaliveSecs(UINT16_MAX), m_tportQueuesize(64), m_bDumpMemory(false),
+        m_nPrometheusPort(0), m_strPrometheusAddress("0.0.0.0"), m_tcpKeepaliveSecs(UINT16_MAX), m_tportQueuesize(64),
+        m_tportMaxConsecutiveTimeouts(0), m_bDumpMemory(false),
         m_minTlsVersion(0), m_bDisableNatDetection(false), m_pBlacklist(nullptr), m_bAlwaysSend180(false),
         m_bGloballyReadableLogs(false), m_bTlsVerifyClientCert(false), m_bRejectRegisterWithNoRealm(false) {
 
@@ -842,6 +843,18 @@ namespace drachtio {
             if (q > 1000) q = 1000; // sofia-sip caps tpp_qsize at 1000 (tport.c)
             m_tportQueuesize = (unsigned int) q;
         }
+        // opt-in dead-connection detection: after N consecutive request timeouts on a
+        // connection-oriented tport, drachtio force-closes it so the next request reconnects; 0 = disabled.
+        // floored at 2 (a value of 1 would risk closing a freshly-rebuilt connection on the
+        // trailing 408s of requests that were already queued on the transport being torn down)
+        // and clamped at 1000 to keep the log/behavior sane, matching the DRACHTIO_TPORT_QUEUESIZE convention.
+        p = std::getenv("DRACHTIO_TPORT_MAX_CONSECUTIVE_TIMEOUTS");
+        if (p && ::atoi(p) > 0) {
+            int n = ::atoi(p);
+            if (n < 2) n = 2;
+            if (n > 1000) n = 1000;
+            m_tportMaxConsecutiveTimeouts = (unsigned int) n;
+        }
         p = std::getenv("DRACHTIO_SECRET");
         if (p) m_secret = p;
         p = std::getenv("DRACHTIO_CONSOLE_LOGGING");
@@ -1292,6 +1305,14 @@ namespace drachtio {
 
         // listen backlog / per-connection send queue depth for tcp/tls/ws/wss transports
         DR_LOG(log_notice) << "transport listen backlog (TPTAG_QUEUESIZE) set to " << m_tportQueuesize;
+
+        if (0 == m_tportMaxConsecutiveTimeouts) {
+            DR_LOG(log_notice) << "tport dead-connection detection is disabled (set DRACHTIO_TPORT_MAX_CONSECUTIVE_TIMEOUTS to enable)";
+        }
+        else {
+            DR_LOG(log_notice) << "tport dead-connection detection: a connection-oriented transport will be closed and rebuilt after "
+                << m_tportMaxConsecutiveTimeouts << " consecutive request timeouts";
+        }
 
         int rv = su_init() ;
         if( rv < 0 ) {

--- a/src/controller.hpp
+++ b/src/controller.hpp
@@ -187,6 +187,7 @@ namespace drachtio {
 
     unsigned int getTcpKeepaliveInterval() { return m_tcpKeepaliveSecs; }
     unsigned int getTportQueuesize() { return m_tportQueuesize; }
+    unsigned int getTportMaxConsecutiveTimeouts() { return m_tportMaxConsecutiveTimeouts; }
 
 	private:
 
@@ -291,6 +292,9 @@ namespace drachtio {
     bool m_bMemoryDebug;
     unsigned int m_tcpKeepaliveSecs;
     unsigned int m_tportQueuesize;
+    // opt-in dead-connection detection: max consecutive request timeouts on a
+    // connection-oriented tport before it is force-closed. 0 = disabled (legacy).
+    unsigned int m_tportMaxConsecutiveTimeouts;
 
     bool m_bDumpMemory;
 

--- a/src/sip-dialog-controller.cpp
+++ b/src/sip-dialog-controller.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include <boost/algorithm/string/replace.hpp>
 
 #include <sofia-sip/su_alloc.h>
+#include <sofia-sip/tport.h>
 
 namespace drachtio {
     class SipDialogController ;
@@ -770,7 +771,61 @@ namespace drachtio {
         deleteTags(tags);
    }
 
+    void SipDialogController::trackTportLiveness(nta_outgoing_t* orq, sip_t const* sip) {
+        unsigned int N = m_pController->getTportMaxConsecutiveTimeouts();
+        if (0 == N) return; // feature disabled: no map access, no tport calls
+
+        // Classify this response's evidence about the transport:
+        //  - timeout: NULL sip (in-dialog / refresh re-INVITE timeout) or an nta-fabricated internal
+        //    408 (out-of-dialog timeout). Counts as "no response" -> increment.
+        //  - alive: a real response received off the wire (not internally generated) -> reset, since
+        //    bytes actually came back over the connection.
+        //  - neither: an nta-fabricated non-408 failure (e.g. internal 503 "No transport", 410) is a
+        //    send-side error, not proof of liveness and not a peer timeout -> leave the counter as-is.
+        bool isInternal = nta_sip_is_internal(sip); // true when sip == NULL
+        bool isTimeout = isInternal &&
+            (NULL == sip || (sip->sip_status && 408 == sip->sip_status->st_status));
+        bool isAlive = !isInternal; // a genuine wire response proves the transport is alive
+
+        // hot healthy path: nothing tracked yet and this response won't change any counter
+        if (!isTimeout && m_mapTportConsecutiveTimeouts.empty()) return;
+
+        tport_t* tp = nta_outgoing_transport(orq); // new reference
+        if (nullptr == tp) return; // DNS-delayed orq; nothing to track yet
+
+        if (!tport_is_secondary(tp) || tport_is_udp(tp)) {
+            // never track/close a primary (listening) transport or a UDP (connectionless) transport
+            tport_unref(tp);
+            return;
+        }
+
+        tp_name_t const* tpn = tport_name(tp);
+        if (!tpn || !tpn->tpn_proto || !tpn->tpn_host || !tpn->tpn_port) {
+            tport_unref(tp);
+            return;
+        }
+        string key = string(tpn->tpn_proto) + "/" + tpn->tpn_host + ":" + tpn->tpn_port;
+
+        if (isTimeout) {
+            unsigned int c = ++m_mapTportConsecutiveTimeouts[key];
+            DR_LOG(log_info) << "SipDialogController::trackTportLiveness - " << key << " consecutive request timeout #" << c << " (threshold " << N << ")";
+            if (c >= N) {
+                DR_LOG(log_warning) << "SipDialogController::trackTportLiveness - " << key << " reached " << N << " consecutive request timeouts; closing transport so the next request reconnects";
+                tport_shutdown(tp, 2);
+                m_mapTportConsecutiveTimeouts.erase(key);
+            }
+        }
+        else if (isAlive) {
+            // a genuine wire response proves the transport is alive; clear any timeout streak.
+            // (internally-generated non-408 failures fall through and leave the counter unchanged)
+            m_mapTportConsecutiveTimeouts.erase(key);
+        }
+
+        tport_unref(tp);
+    }
+
     int SipDialogController::processResponseOutsideDialog( nta_outgoing_t* orq, sip_t const* sip )  {
+        trackTportLiveness(orq, sip);
         DR_LOG(log_debug) << "SipDialogController::processResponseOutsideDialog"  ;
         string transactionId ;
         std::shared_ptr<SipDialog> dlg ;
@@ -1805,6 +1860,7 @@ namespace drachtio {
         return rc ;
     }
     int SipDialogController::processResponseInsideDialog( nta_outgoing_t* orq, sip_t const* sip )  {
+        trackTportLiveness(orq, sip);
         DR_LOG(log_debug) << "SipDialogController::processResponseInsideDialog: "  ;
     	ostringstream o ;
         std::shared_ptr<RIP> rip  ;
@@ -1877,6 +1933,7 @@ namespace drachtio {
 		return 0 ;
     }
     int SipDialogController::processResponseToRefreshingReinvite( nta_outgoing_t* orq, sip_t const* sip ) {
+        trackTportLiveness(orq, sip);
         DR_LOG(log_debug) << "SipDialogController::processResponseToRefreshingReinvite: "  ;
         std::shared_ptr<RIP> rip  ;
 

--- a/src/sip-dialog-controller.hpp
+++ b/src/sip-dialog-controller.hpp
@@ -263,6 +263,7 @@ namespace drachtio {
 	protected:
  		bool searchForHeader( tagi_t* tags, tag_type_t header, string& value ) ;
 		void bindIrq( nta_incoming_t* irq ) ;
+		void trackTportLiveness(nta_outgoing_t* orq, sip_t const* sip);
 
 
 	private:
@@ -305,6 +306,9 @@ namespace drachtio {
 
 		// timers for dialogs and leg that we can remove after suitable timeout period waiting for retransmissions
     std::shared_ptr<TimerQueueManager> m_pTQM ;
+
+		// per-tport count of consecutive internally-generated request timeouts (408s); accessed only on the su_root thread
+		std::unordered_map<std::string, unsigned int> m_mapTportConsecutiveTimeouts;
 	} ;
 
 }


### PR DESCRIPTION
Persistent outbound connection-oriented transports (TLS/TCP/WSS) to SIP peers can wedge: TCP stays ESTABLISHED and ACKing while SIP payload no longer flows (carrier SBC failover, middlebox losing session state, TLS desync). drachtio had no way to detect or rebuild such a connection short of a full restart. sofia's CRLF keepalive (TPTAG_KEEPALIVE/PINGPONG) does not help: the TLS transport has no keepalive timer vtable, so the ping is never sent on TLS.

Detect the wedge at the nta layer instead: count consecutive request timeouts per outbound tport in the three response callbacks (a timeout is a NULL sip or an nta-fabricated internal 408; a genuine wire response resets the streak; internal non-408 failures leave it unchanged). After N consecutive timeouts (env DRACHTIO_TPORT_MAX_CONSECUTIVE_TIMEOUTS, floored 2, clamped 1000, default 0 = disabled = legacy) the transport is force-closed via tport_shutdown so the next request reconnects. Works for all connection-oriented transports regardless of TLS; never touches primary/UDP tports; single sofia-thread.