### PR TITLE
fix(nat): preserve TLS transport on UAC NAT route rewrite

### DIFF
--- a/src/sip-dialog-controller.cpp
+++ b/src/sip-dialog-controller.cpp
@@ -869,7 +869,23 @@ namespace drachtio {
                     }
                     else {
                       url_t const * url = nta_outgoing_route_uri(orq);
-                      string routeUri = string((url ? url->url_scheme : "sip")) + ":" + meta.getAddress() + ":" + meta.getPort();
+                      // Preserve TLS on the in-dialog route. When the INVITE was sent over TLS,
+                      // a bare "sip:<ip>:<port>" here makes the ACK (and later in-dialog requests)
+                      // default to UDP, so the remote never sees the ACK on the TLS dialog and
+                      // clears the call with 408. Read the transport the request was actually sent
+                      // on (tpn_proto: udp/tcp/tls/ws/wss) and only rewrite the TLS case; every
+                      // other transport keeps the historical bare route unchanged (ws/wss/tcp
+                      // NAT dialogs are unaffected).
+                      tport_t* tp = nta_outgoing_transport(orq); // takes a reference
+                      const char* proto = tp ? tport_name(tp)->tpn_proto : NULL;
+                      string routeUri;
+                      if (proto && 0 == strcmp(proto, "tls")) {
+                        routeUri = "sips:" + meta.getAddress() + ":" + meta.getPort() + ";transport=tls";
+                      }
+                      else {
+                        routeUri = string((url ? url->url_scheme : "sip")) + ":" + meta.getAddress() + ":" + meta.getPort();
+                      }
+                      if (tp) tport_unref(tp);
                       dlg->setRouteUri(routeUri);
                       DR_LOG(log_info) << "SipDialogController::processResponseOutsideDialog - (UAC) detected nat setting route to: " <<   routeUri;
                     }


### PR DESCRIPTION
When a UAC receives a 200 OK whose Contact host differs from the packet source IP with no Record-Route, processResponseOutsideDialog treats it as NAT and rebuilds the in-dialog route from the source address. It built a bare "sip:<ip>:<port>", so for a dialog established over TLS the ACK (and later in-dialog requests) defaulted to UDP -- the remote never saw the ACK on the TLS dialog, retransmitted 200 OK, and cleared the call with BYE cause=408 (~25% of outbound dial type:sip over TLS).

Read the transport the request was actually sent on via tport_name(nta_outgoing_transport(orq))->tpn_proto and, only for TLS, build "sips:<ip>:<port>;transport=tls" so the ACK follows the dialog transport. udp/tcp/ws/wss keep the historical bare route unchanged, so WebSocket/WebRTC NAT dialogs are unaffected.