### PR TITLE
fix(client): evict wedged clients and make remove_route verb-scoped

### DIFF
--- a/src/client-controller.cpp
+++ b/src/client-controller.cpp
@@ -128,6 +128,11 @@ namespace drachtio {
         DR_LOG(log_info) << "ClientController::join - Added client, count of connected clients is now: " << m_clients.size()  ;       
     }
     void ClientController::leave( client_ptr client ) {
+        /* remove any request registrations the client still holds, so that
+           round-robin dispatch cannot select a client that is gone; an entry
+           whose weak_ptr is kept alive by a never-completing write would
+           otherwise linger in the pool black-holing requests */
+        no_longer_wants_requests( client, "" ) ;
         m_clients.erase( client ) ;
         time_t duration = client->getConnectionDuration();
         DR_LOG(log_info) << "ClientController::leave - Removed client, connection duration " << std::dec << 
@@ -228,21 +233,20 @@ namespace drachtio {
 
 
     bool ClientController::no_longer_wants_requests( client_ptr client, const string& verb ) {
-        RequestSpecifier spec( client ) ;
         std::lock_guard<std::mutex> l( m_lock ) ;
-        // Remove all instances of this client for this verb
+        // Remove this client's registrations: all of them if verb is empty, otherwise only that verb's
         for (map_of_request_types::iterator it = m_request_types.begin(); it != m_request_types.end(); ) {
-            if (it->second.client() == client) {
+            if (it->second.client() == client && (verb.empty() || 0 == verb.compare(it->first))) {
                 it = m_request_types.erase(it);
             }
             else {
                 ++it;
             }
         }
-        DR_LOG(log_debug) << "Removed client for " << verb << " requests"  ;
+        DR_LOG(log_debug) << "Removed client for " << (verb.empty() ? "all" : verb.c_str()) << " requests"  ;
 
         //TODO: validate the verb is supported
-        return true ;  
+        return true ;
     }
 
     client_ptr ClientController::selectClientForRequestOutsideDialog(const char* keyword, const char* tag) {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -393,17 +393,7 @@ namespace drachtio {
 
             /* send response if indicated */
             if( !msgResponse.empty() ) {
-                int len = std::size(msgResponse);
-                auto forthelifeofsend = std::make_shared<std::string>(
-                    std::to_string(len) + std::string("#") + msgResponse
-                );
-
-                auto self(shared_from_this());
-                DR_LOG(log_debug) << "Sending response: " << *forthelifeofsend << endl ;
-                boost::asio::async_write( m_sock, boost::asio::buffer( *forthelifeofsend ), 
-                    [self, forthelifeofsend](const boost::system::error_code& ec, std::size_t bytes_transferred) {
-                        DR_LOG(log_debug) << "Client::read_handler - wrote " << bytes_transferred << " bytes: " << ec  ;
-                    } );
+                send( msgResponse ) ;
             }
             if( !bContinue ) {
                  DR_LOG(log_error) << "Client::read_handler - disconnecting client due to error processing client message" ;
@@ -446,7 +436,49 @@ read_again:
 
     template<typename T, typename S>
     void Client<T,S>::write_handler( const boost::system::error_code& ec, std::size_t bytes_transferred ) {
-        DR_LOG(log_debug) << "Client::write_handler - wrote " << bytes_transferred << " bytes: " << ec  ;
+        if( m_nWritesOutstanding > 0 ) m_nWritesOutstanding-- ;
+        if( ec ) {
+            /* operation_aborted means we are already tearing this client down */
+            if( boost::asio::error::operation_aborted == ec ) return ;
+            DR_LOG(log_error) << "Client::write_handler - error writing to client " << m_strRemoteAddress << ":" <<
+                std::dec << m_nRemotePort << ", disconnecting: " << ec ;
+            forceClose() ;
+            return ;
+        }
+        DR_LOG(log_debug) << "Client::write_handler - wrote " << bytes_transferred << " bytes"  ;
+        if( 0 == m_nWritesOutstanding ) {
+            m_writeTimerGen++ ;
+            m_writeTimer.cancel() ;
+        }
+        else {
+            /* forward progress was made; give the remaining writes a fresh deadline */
+            startWriteTimer() ;
+        }
+    }
+
+    template<typename T, typename S>
+    void Client<T,S>::startWriteTimer() {
+        unsigned int secs = theOneAndOnlyController->getClientWriteTimeout() ;
+        if( 0 == secs ) return ;
+        uint64_t gen = ++m_writeTimerGen ;
+        m_writeTimer.expires_after( std::chrono::seconds(secs) ) ;
+        auto self( shared_from_this() ) ;
+        m_writeTimer.async_wait( [this, self, gen, secs]( const boost::system::error_code& ec ) {
+            if( ec || gen != m_writeTimerGen ) return ;
+            DR_LOG(log_error) << "Client::startWriteTimer - no write to client " << m_strRemoteAddress << ":" <<
+                std::dec << m_nRemotePort << " has completed in " << secs << " seconds with " <<
+                m_nWritesOutstanding << " writes outstanding; evicting unresponsive client" ;
+            forceClose() ;
+        } ) ;
+    }
+
+    template<typename T, typename S>
+    void Client<T,S>::forceClose() {
+        m_writeTimerGen++ ;
+        m_writeTimer.cancel() ;
+        m_controller.leave( shared_from_this() ) ;
+        boost::system::error_code ec ;
+        m_sock.lowest_layer().close( ec ) ;
     }
 
     template<typename T, typename S>
@@ -454,7 +486,7 @@ read_again:
         int len = std::size(str);
 
         if (0 == len) {
-            DR_LOG(log_info) << "Client::send - we are unable to send this message back to client" << str; 
+            DR_LOG(log_info) << "Client::send - we are unable to send this message back to client" << str;
             return;
         }
 
@@ -464,9 +496,10 @@ read_again:
 
         auto self(shared_from_this());
         DR_LOG(log_debug) << "Sending: " << *forthelifeofsend << endl ;
-        boost::asio::async_write( m_sock, boost::asio::buffer( *forthelifeofsend ), 
-            [self, forthelifeofsend](const boost::system::error_code& ec, std::size_t bytes_transferred) {
-                DR_LOG(log_debug) << "Client::send - wrote " << bytes_transferred << " bytes: " << ec  ;
+        if( 0 == m_nWritesOutstanding++ ) startWriteTimer() ;
+        boost::asio::async_write( m_sock, boost::asio::buffer( *forthelifeofsend ),
+            [this, self, forthelifeofsend](const boost::system::error_code& ec, std::size_t bytes_transferred) {
+                write_handler( ec, bytes_transferred ) ;
             } );
     }
 
@@ -475,15 +508,15 @@ read_again:
     template<>
     Client<socket_t>::Client(boost::asio::io_context& io_context, ClientController& controller) :
         BaseClient(controller),
-        m_sock(io_context) {
+        m_sock(io_context), m_writeTimer(io_context), m_nWritesOutstanding(0), m_writeTimerGen(0) {
     }
 
     template<>
     Client<socket_t>::Client( boost::asio::io_context& io_context, ClientController& controller,
-        const string& transactionId, const string& host, 
+        const string& transactionId, const string& host,
         const string& port ) :
         BaseClient(controller, transactionId, host, port),
-        m_sock(io_context) {
+        m_sock(io_context), m_writeTimer(io_context), m_nWritesOutstanding(0), m_writeTimerGen(0) {
 
     }
 
@@ -548,14 +581,14 @@ read_again:
     template<>
     Client<ssl_socket_t, ssl_socket_t::lowest_layer_type>::Client(boost::asio::io_context& io_context, boost::asio::ssl::context& context, ClientController& controller) :
         BaseClient(controller),
-        m_sock(io_context, context) {
+        m_sock(io_context, context), m_writeTimer(io_context), m_nWritesOutstanding(0), m_writeTimerGen(0) {
     }
 
     template<>
     Client<ssl_socket_t, ssl_socket_t::lowest_layer_type>::Client( boost::asio::io_context& io_context, boost::asio::ssl::context& context, ClientController& controller,
         const string& transactionId, const string& host, const string& port ) :
         BaseClient(controller, transactionId, host, port),
-        m_sock(io_context, context) {
+        m_sock(io_context, context), m_writeTimer(io_context), m_nWritesOutstanding(0), m_writeTimerGen(0) {
 
         m_sock.set_verify_mode(boost::asio::ssl::verify_none);
     }

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -135,9 +135,19 @@ namespace drachtio {
         T& socket() { return m_sock; }
 
     protected:
-        void send( const string& str );  
+        void send( const string& str );
+        void startWriteTimer();
+        void forceClose();
 
         T m_sock;
+
+        /* watchdog for wedged clients: if writes are outstanding and none
+           completes within the deadline, the client is evicted and its
+           socket closed.  m_writeTimerGen guards against a stale timer
+           handler that was already queued when the timer was re-armed. */
+        boost::asio::steady_timer m_writeTimer;
+        unsigned int m_nWritesOutstanding;
+        uint64_t m_writeTimerGen;
 
     private:
         Client();  // prohibited

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -291,7 +291,7 @@ namespace drachtio {
         m_current_severity_threshold(log_none), m_nSofiaLoglevel(-1), m_bIsOutbound(false), m_bConsoleLogging(false),
         m_nHomerPort(0), m_nHomerId(0), m_mtu(0), m_bAggressiveNatDetection(false), m_bMemoryDebug(false),
         m_nPrometheusPort(0), m_strPrometheusAddress("0.0.0.0"), m_tcpKeepaliveSecs(UINT16_MAX), m_tportQueuesize(64),
-        m_tportMaxConsecutiveTimeouts(0), m_bDumpMemory(false),
+        m_tportMaxConsecutiveTimeouts(0), m_clientWriteTimeoutSecs(0), m_bDumpMemory(false),
         m_minTlsVersion(0), m_bDisableNatDetection(false), m_pBlacklist(nullptr), m_bAlwaysSend180(false),
         m_bGloballyReadableLogs(false), m_bTlsVerifyClientCert(false), m_bRejectRegisterWithNoRealm(false) {
 
@@ -855,6 +855,18 @@ namespace drachtio {
             if (n > 1000) n = 1000;
             m_tportMaxConsecutiveTimeouts = (unsigned int) n;
         }
+        // opt-in wedged-client detection: if writes to an app connection are outstanding and
+        // none completes within this many seconds (the client stopped reading, so its tcp
+        // receive window closed and never re-opened), the client is evicted and its socket
+        // closed; 0 = disabled. floored at 2 to avoid hair-trigger evictions of a briefly
+        // stalled but healthy client, clamped at 3600 to keep the behavior sane.
+        p = std::getenv("DRACHTIO_CLIENT_WRITE_TIMEOUT");
+        if (p && ::atoi(p) > 0) {
+            int n = ::atoi(p);
+            if (n < 2) n = 2;
+            if (n > 3600) n = 3600;
+            m_clientWriteTimeoutSecs = (unsigned int) n;
+        }
         p = std::getenv("DRACHTIO_SECRET");
         if (p) m_secret = p;
         p = std::getenv("DRACHTIO_CONSOLE_LOGGING");
@@ -1312,6 +1324,14 @@ namespace drachtio {
         else {
             DR_LOG(log_notice) << "tport dead-connection detection: a connection-oriented transport will be closed and rebuilt after "
                 << m_tportMaxConsecutiveTimeouts << " consecutive request timeouts";
+        }
+
+        if (0 == m_clientWriteTimeoutSecs) {
+            DR_LOG(log_notice) << "client write watchdog is disabled (set DRACHTIO_CLIENT_WRITE_TIMEOUT to enable)";
+        }
+        else {
+            DR_LOG(log_notice) << "client write watchdog: an application connection will be evicted if none of its pending writes completes within "
+                << m_clientWriteTimeoutSecs << " seconds";
         }
 
         int rv = su_init() ;

--- a/src/controller.hpp
+++ b/src/controller.hpp
@@ -188,6 +188,7 @@ namespace drachtio {
     unsigned int getTcpKeepaliveInterval() { return m_tcpKeepaliveSecs; }
     unsigned int getTportQueuesize() { return m_tportQueuesize; }
     unsigned int getTportMaxConsecutiveTimeouts() { return m_tportMaxConsecutiveTimeouts; }
+    unsigned int getClientWriteTimeout() { return m_clientWriteTimeoutSecs; }
 
 	private:
 
@@ -295,6 +296,10 @@ namespace drachtio {
     // opt-in dead-connection detection: max consecutive request timeouts on a
     // connection-oriented tport before it is force-closed. 0 = disabled (legacy).
     unsigned int m_tportMaxConsecutiveTimeouts;
+    // opt-in wedged-client detection: seconds that writes to an app connection
+    // may go without a single completion before the client is evicted and its
+    // socket closed. 0 = disabled (legacy).
+    unsigned int m_clientWriteTimeoutSecs;
 
     bool m_bDumpMemory;
 

--- a/test/package.json
+++ b/test/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test-ci": "NODE_ENV=test node ./index.js",
-    "test": "NODE_ENV=test node ./index.js && node ./connection_tests_ci.js"
+    "test-ci": "NODE_ENV=test node ./index.js && node ./zombie-client-tests.js",
+    "test": "NODE_ENV=test node ./index.js && node ./zombie-client-tests.js && node ./connection_tests_ci.js"
   },
   "author": "Dave Horton",
   "license": "MIT",

--- a/test/scenarios/uac-options-routed-expect-200.xml
+++ b/test/scenarios/uac-options-routed-expect-200.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- Like uac-options-expect-200.xml, but with a User-Agent that does NOT   -->
+<!-- match the user-agent-options-auto-respond setting in drachtio.conf.xml -->
+<!-- so the OPTIONS must be routed to a connected client to get a 200.      -->
+
+<scenario name="Basic Sipstone UAC">
+
+  <send retrans="500">
+    <![CDATA[
+
+      OPTIONS sip:[service]@[remote_ip]:[remote_port] SIP/2.0
+      Via: SIP/2.0/[transport] [local_ip]:[local_port];branch=[branch]
+      From: sipp <sip:sipp@[local_ip]:[local_port]>;tag=[pid]SIPpTag00[call_number]
+      To: [service] <sip:[service]@[remote_ip]:[remote_port]>
+      Call-ID: [call_id]
+      CSeq: 1 OPTIONS
+      Subject: uac-options-routed-expect-200
+      User-Agent: health-checker
+      Content-Length: 0
+
+      ]]>
+  </send>
+
+  <recv response="200" rtd="true">
+  </recv>
+
+</scenario>

--- a/test/scripts/wedge-client.js
+++ b/test/scripts/wedge-client.js
@@ -1,0 +1,120 @@
+const net = require('net');
+const Emitter = require('events');
+const crypto = require('crypto');
+const debug = require('debug')('drachtio:server-test');
+
+/**
+ * A minimal drachtio wire-protocol client used to simulate a wedged
+ * application: one that connects, authenticates and registers a route,
+ * then stops reading from its socket -- as a hung or overloaded process
+ * would.  Once its kernel receive buffer fills, the server's writes to it
+ * stop completing, which is the condition that turned a dead client into
+ * a routing zombie in production.
+ *
+ * Note: framing below treats string length as byte length, which holds
+ * because the admin protocol traffic in these tests is all ASCII.
+ */
+class WedgeClient extends Emitter {
+  constructor() {
+    super();
+    this.socket = null;
+    this.pending = new Map();
+    this.incoming = '';
+    this.closed = false;
+  }
+
+  connect({host = '127.0.0.1', port = 9022, secret = 'cymru'} = {}) {
+    return new Promise((resolve, reject) => {
+      this.socket = net.connect({host, port}, () => {
+        this._request(`authenticate|${secret}`)
+          .then((tokens) => {
+            if ('OK' !== tokens[0]) return reject(new Error('authentication failed'));
+            resolve();
+          })
+          .catch(reject);
+      });
+      this.socket.setNoDelay(true);
+      this.socket.on('data', (data) => this._onData(data));
+      this.socket.on('error', (err) => debug(`wedge-client socket error: ${err.message}`));
+      this.socket.on('close', () => {
+        this.closed = true;
+        this.emit('close');
+      });
+    });
+  }
+
+  route(verb) {
+    return this._request(`route|${verb}`).then((tokens) => {
+      if ('OK' !== tokens[0]) throw new Error(`route request for ${verb} refused`);
+    });
+  }
+
+  /* stop reading from the socket, like a hung process: the kernel receive
+     buffer fills, our tcp window closes, and the server's writes to us
+     stop completing */
+  wedge() {
+    this.socket.pause();
+  }
+
+  /* fire off n pings without reading any responses; the server's replies
+     pile up in its kernel send buffer until its writes to us jam */
+  flood(n) {
+    for (let i = 0; i < n; i++) this._write('ping');
+  }
+
+  disconnect() {
+    if (this.socket) this.socket.destroy();
+  }
+
+  _write(msg) {
+    const msgId = crypto.randomUUID();
+    const s = `${msgId}|${msg}`;
+    this.socket.write(`${Buffer.byteLength(s, 'utf8')}#${s}`);
+    return msgId;
+  }
+
+  _request(msg) {
+    return new Promise((resolve, reject) => {
+      const msgId = this._write(msg);
+      const timer = setTimeout(() => {
+        this.pending.delete(msgId);
+        reject(new Error(`timeout waiting for response to ${msg}`));
+      }, 4000);
+      this.pending.set(msgId, (tokens) => {
+        clearTimeout(timer);
+        resolve(tokens);
+      });
+    });
+  }
+
+  _onData(data) {
+    this.incoming += data.toString();
+    for (;;) {
+      const idx = this.incoming.indexOf('#');
+      if (-1 === idx) return;
+      const len = parseInt(this.incoming.slice(0, idx), 10);
+      const start = idx + 1;
+      if (this.incoming.length < start + len) return;
+      const payload = this.incoming.slice(start, start + len);
+      this.incoming = this.incoming.slice(start + len);
+      this._onMessage(payload);
+    }
+  }
+
+  _onMessage(payload) {
+    const tokens = payload.split('|');
+    // response format: <uuid>|response|<request msgId>|OK|...
+    if ('response' === tokens[1]) {
+      const cb = this.pending.get(tokens[2]);
+      if (cb) {
+        this.pending.delete(tokens[2]);
+        cb(tokens.slice(3));
+      }
+    }
+    else if ('sip' === tokens[1]) {
+      this.emit('sip', payload);
+    }
+  }
+}
+
+module.exports = WedgeClient;

--- a/test/zombie-client-tests.js
+++ b/test/zombie-client-tests.js
@@ -1,0 +1,137 @@
+const test = require('blue-tape');
+const {start, stop} = require('./testbed');
+const {exec} = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const Uas = require('./scripts/uas');
+const WedgeClient = require('./scripts/wedge-client');
+const delay = require('./utils/delay');
+const debug = require('debug')('drachtio:server-test');
+
+const execCmd = (cmd, opts) => {
+  opts = opts || {};
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      exec(cmd, opts, (err, stdout, stderr) => {
+        if (stdout) debug(stdout);
+        if (stderr) debug(stderr);
+        if (err) return reject(err);
+        resolve();
+      });
+    }, 750);
+  });
+};
+
+/* poll a log file until it matches, or give up after timeoutMs */
+const waitForLogMatch = (logPath, re, timeoutMs) => {
+  const startAt = Date.now();
+  return new Promise((resolve) => {
+    const check = () => {
+      let content = '';
+      try {
+        content = fs.readFileSync(logPath, {encoding: 'utf8'});
+      } catch (e) { /* not written yet */ }
+      if (re.test(content)) return resolve(true);
+      if (Date.now() - startAt > timeoutMs) return resolve(false);
+      setTimeout(check, 500);
+    };
+    check();
+  });
+};
+
+/**
+ * Regression test for the zombie-client outage: a client whose socket
+ * writes never complete (it stopped reading, so its tcp window closed)
+ * must be evicted from the request-dispatch pool rather than left in
+ * round-robin rotation black-holing every third INVITE.
+ */
+test('wedged client is evicted and INVITEs only route to healthy clients', async(t) => {
+  const logPath = path.join(os.tmpdir(), `drachtio-wedge-test-${process.pid}.log`);
+  let uas1, uas2, wedge;
+  try {
+    /* short write timeout so the test doesn't dawdle */
+    await start(null, [], false, 1000, {DRACHTIO_CLIENT_WRITE_TIMEOUT: '4'}, logPath);
+
+    uas1 = new Uas();
+    uas2 = new Uas();
+    await uas1.connect();
+    uas1.accept();
+    await uas2.connect();
+    uas2.accept();
+
+    wedge = new WedgeClient();
+    await wedge.connect();
+    await wedge.route('invite');
+
+    /* stop reading, then make the server write to us until its sends jam;
+       in production this was app traffic to a hung client, here pings do it.
+       the volume must exceed what the kernels will buffer between the two
+       sockets (with autotuning, several MB): 100k pings draw ~9MB of
+       responses, comfortably past it */
+    wedge.wedge();
+    wedge.flood(100000);
+
+    const evicted = await waitForLogMatch(logPath, /evicting unresponsive client/, 15000);
+    t.ok(evicted, 'server evicted the wedged client after writes stopped completing');
+
+    for (let i = 0; i < 6; i++) {
+      await execCmd('sipp -sf ./uac.xml 127.0.0.1:5090 -m 1 -timeout 10s -timeout_error', {cwd: './scenarios'});
+    }
+    t.equal(uas1.calls + uas2.calls, 6, 'all 6 INVITEs were answered by the healthy clients');
+    t.ok(uas1.calls >= 2 && uas2.calls >= 2, 'both healthy clients took calls');
+  } finally {
+    if (wedge) wedge.disconnect();
+    if (uas1) uas1.disconnect();
+    if (uas2) uas2.disconnect();
+    await stop();
+  }
+});
+
+/**
+ * Regression test for remove_route: unregistering one verb must not drop
+ * the client's other registrations (a draining instance stops taking new
+ * INVITEs but must keep answering OPTIONS health checks).
+ */
+test('unregistering one verb leaves the client\'s other routes intact', async(t) => {
+  let uasA, uasB;
+  let optionsReceived = 0;
+  try {
+    await start();
+
+    uasA = new Uas();
+    await uasA.connect();
+    uasA.srf.options((req, res) => {
+      optionsReceived++;
+      res.send(200);
+    });
+    uasA.accept();
+
+    uasB = new Uas();
+    await uasB.connect();
+    uasB.accept();
+    await delay(500);
+
+    uasA.srf.unregisterForMessages('invite');
+    await delay(500);
+
+    /* OPTIONS from a non-auto-answered user-agent must still reach uasA */
+    await execCmd('sipp -sf ./uac-options-routed-expect-200.xml 127.0.0.1:5090 -m 1 -timeout 10s -timeout_error',
+      {cwd: './scenarios'});
+    t.equal(optionsReceived, 1, 'client still receives OPTIONS after unregistering only invite');
+
+    await execCmd('sipp -sf ./uac.xml 127.0.0.1:5090 -m 1 -timeout 10s -timeout_error', {cwd: './scenarios'});
+    await execCmd('sipp -sf ./uac.xml 127.0.0.1:5090 -m 1 -timeout 10s -timeout_error', {cwd: './scenarios'});
+    t.equal(uasB.calls, 2, 'all INVITEs went to the client still registered for invite');
+    t.equal(uasA.calls, 0, 'no INVITEs went to the client that unregistered invite');
+  } finally {
+    if (uasA) uasA.disconnect();
+    if (uasB) uasB.disconnect();
+    await stop();
+  }
+});
+
+test('finish up', (t) => {
+  t.end();
+  process.exit(0);
+});


### PR DESCRIPTION
A connected application that stops reading its admin socket (hung or overloaded process) wedges its connection: drachtio's writes to it stop completing once the tcp window closes, but no error is ever surfaced -- a zero-window peer looks healthy to the stack. Each pending async_write holds a shared_ptr to the Client, so the object is never destroyed, its weak_ptrs in the request-dispatch pool never expire, and round-robin keeps routing new requests into the dead connection, black-holing them until drachtio is restarted. We hit this in production: one wedged app instance black-holed a third of incoming INVITEs (and the OPTIONS health checks routed to it) for days; restarting the app did not clear it, because the zombie lived in drachtio's heap.

Three fixes:

- Client::send/write_handler: act on write errors (previously the error code was logged and discarded) by removing the client and closing its socket; and add an opt-in write-progress watchdog: if writes are outstanding and none completes within DRACHTIO_CLIENT_WRITE_TIMEOUT seconds (floored 2, clamped 3600, default 0 = disabled = legacy, matching the DRACHTIO_TPORT_MAX_CONSECUTIVE_TIMEOUTS convention from #488), the client is evicted and its socket closed. The watchdog is required for the zero-window case: a jammed async_write never completes at all, so acting on errors alone can never fire.

- ClientController::leave purges the departing client's entries from the request-dispatch pool rather than leaving them to linger until its weak_ptrs expire (which never happens while pending writes pin the object).

- ClientController::no_longer_wants_requests respects its verb argument: remove_route for one verb no longer drops the client's other registrations, so an app can call srf.unregisterForMessages('invite') to drain ahead of a deploy while still answering OPTIONS health checks. An empty verb removes all registrations (used by leave()).

The read_handler response path now routes through send() so all client writes share the error handling and watchdog.

Regression tests (test/zombie-client-tests.js, wired into test-ci): a raw wire-protocol client (test/scripts/wedge-client.js) authenticates, registers for invite, stops reading its socket, and floods pings until the server's writes jam; the test asserts drachtio evicts the wedged client and every subsequent INVITE lands on the two healthy clients. Before the fix, drachtio kept "3 possible clients" in rotation and round-robined every third INVITE into the dead socket. A second test asserts OPTIONS is still routed to a client after it unregisters only invite, using a new OPTIONS scenario whose User-Agent does not match the auto-respond setting. Both tests were written first and failed against main, then pass with the fix; the full suite is green on macOS and on an ubuntu 24.04 container mirroring ci.yml (apt boost 1.83, tcmalloc, node 20, sipp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
